### PR TITLE
Making globals more global

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -63,7 +63,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             });
         }
 
-        View::composer('rapidez::layouts.app', function ($view) {
+        View::composer('*', function ($view) {
             foreach (GlobalSet::all() as $set) {
                 foreach ($set->localizations() as $locale => $variables) {
                     if ($locale == Site::current()->handle()) {

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -61,7 +61,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
 
     private function getGlobals() : array
     {
-        return Cache::rememberForever('statamic-globals', function() {
+        return Cache::rememberForever('statamic-globals-'.Site::current()->handle(), function() {
             foreach (GlobalSet::all() as $set) {
                 foreach ($set->localizations() as $locale => $variables) {
                     if ($locale == Site::current()->handle()) {
@@ -92,7 +92,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
     public function bootListeners() : self
     {
         Event::listen([GlobalSetSaved::class, GlobalSetDeleted::class], function() {
-            Cache::forget("statamic-globals");
+            Cache::forget('statamic-globals-'.Site::current()->handle());
         });
 
         return $this;

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -82,10 +82,13 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             });
         }
 
-        View::composer('rapidez::*', function ($view) {
-            $view->with('globals', (object)$this->getGlobals());
+        View::composer('*', function ($view) {
+            if(!isset($view->globals))
+            {
+                $view->with('globals', (object)$this->getGlobals());
+            }
         });
-
+        
         return $this;
     }
 


### PR DESCRIPTION
This gives content pages that would previously not have access to globals, access to globals from statamic.

I'm personally unsure why the previous version didn't apply to content pages that extend rapidez::layouts.app. This just kinda forces it to work, and there's almost certainly a cleaner way.