### PR TITLE
Add command to import magento categories into statamic entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ By default you'll get the configured content on categories and products availabl
 - Product: `resources/views/vendor/rapidez/product/overview.blade.php`
 - Category: `resources/views/vendor/rapidez/category/overview.blade.php`
 
+### Importing categories from Magento
+
+To make it easier to change category content in bulk you can create category entries with content copied over in bulk.
+
+To do this run one of the following:
+
+```bash
+# Most basic, import all categories in all sites
+php artisan rapidez:statamic:import:categories --all
+
+# Import all categories in the site with handle "default" only
+php artisan rapidez:statamic:import:categories --all --site=default
+
+# import select categories in multiple sites
+php artisan rapidez:statamic:import:categories 5 8 9 category-url-key --site=default --site=another_site
+```
+
+By default the slug and title of the category are copied.
+
+If you have a custom blueprint and would like to add more data from the category you can do so by hooking into the `rapidez-statamic:category-entry-data` event:
+
+```php
+Event::listen('rapidez-statamic:category-entry-data', fn($category) => [
+        'description' => $category->description,
+    ]
+);
+```
 ### Forms
 
 When you create a form you could use `rapidez-statamic::emails.form` as HTML template which uses the [Laravel mail template](https://laravel.com/docs/master/mail#customizing-the-components) with all fields in a table, make sure you enable markdown!

--- a/src/Commands/ImportCategories.php
+++ b/src/Commands/ImportCategories.php
@@ -52,7 +52,6 @@ class ImportCategories extends Command
                 ->unless($categoryIdentifiers, fn ($query) => $query
                     ->whereNotNull('url_key')
                     ->whereNot('url_key', 'default-category')
-                    ->where('children_count', '>', 0)
                 )
                 ->when($categoryIdentifiers, fn ($query) => $query
                     ->whereIn($categoryModelInstance->getQualifiedKeyName(), $categoryIdentifiers)

--- a/src/Commands/ImportCategories.php
+++ b/src/Commands/ImportCategories.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Rapidez\Statamic\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Rapidez\Core\Facades\Rapidez;
+use Rapidez\Statamic\Jobs\ImportCategoriesJob;
+use ReflectionClass;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class ImportCategories extends Command
+{
+    protected $signature = 'rapidez:statamic:import:categories {categories?* : Categories in a space separated list, by entity_id or url_key} {--all : Process all categories if none have been passed} {--site=* : Sites handles or urls to process, if none are passed it will be done for all sites (Default will be all sites)}';
+
+    protected $description = 'Create a new category entry for a category if it does not exist.';
+
+    public function handle(): int
+    {
+        $categoryModel = config('rapidez.models.category');
+        $categoryModelInstance = new $categoryModel;
+
+        $categoryIdentifiers = $this->argument('categories');
+        if (!$categoryIdentifiers && !$this->option('all')) {
+            $this->error(__('You must enter categories or pass the --all flag.'));
+
+            return static::FAILURE;
+        }
+
+        $sites = $this->option('site');
+        $sites = $sites
+            ? array_filter(array_map(fn($handle) => (Site::get($handle) ?: Site::findByUrl($handle)) ?: $this->output->warning(__('No site found with handle or url: :handle', ['handle' => $handle])), $sites))
+            : Site::all();
+
+        $bar = $this->output->createProgressBar(count($sites));
+        $bar->start();
+        foreach($sites as $site) {
+            $bar->display();
+
+            $siteAttributes = $site->attributes();
+            if (!isset($siteAttributes['magento_store_id'])) {
+                continue;
+            }
+
+            Rapidez::setStore($siteAttributes['magento_store_id']);
+
+            $categories = $categoryModel::query()
+                ->unless($categoryIdentifiers, fn ($query) => $query
+                    ->whereNotNull('url_key')
+                    ->whereNot('url_key', 'default-category')
+                    ->where('children_count', '>', 0)
+                )
+                ->when($categoryIdentifiers, fn ($query) => $query
+                    ->whereIn($categoryModelInstance->getQualifiedKeyName(), $categoryIdentifiers)
+                    ->orWhereIn('url_key', $categoryIdentifiers)
+                )
+                ->lazy();
+
+            foreach ($categories as $category) {
+                static::createEntry(
+                    [
+                        'collection' => 'categories',
+                        'blueprint'  => 'category',
+                        'site'       => $site->handle(),
+                        'linked_category' => $category->entity_id,
+                    ],
+                    array_merge(...Event::dispatch('rapidez-statamic:category-entry-data', ['category' => $category]))
+                );
+            }
+
+            $bar->advance();
+        }
+        $bar->finish();
+
+
+        return static::SUCCESS;
+    }
+
+    protected static function createEntry(array $attributes, array $values = [])
+    {
+        if (Entry::query()->where($attributes)->count()) {
+            // Entry was already created.
+            return;
+        }
+
+        /** @var \Statamic\Entries\Entry $entry */
+        $entry = Entry::make();
+        $values = array_merge($attributes, $values);
+
+        static::setEntryData($entry, $values)->save();
+    }
+
+    protected static function setEntryData(\Statamic\Entries\Entry $entry, array $values = []) : \Statamic\Entries\Entry
+    {
+        $reflectedEntry = new ReflectionClass($entry);
+        foreach ($values as $key => $value) {
+            // Check if the key is a statamic setter
+            if (!$reflectedEntry->hasMethod($key) || $reflectedEntry->getMethod($key)->getNumberOfParameters() < 1) {
+                continue;
+            }
+
+            $entry->$key($value);
+            unset($values[$key]);
+        }
+
+        $entry->merge($values);
+
+        return $entry;
+    }
+}

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\View as RenderedView;
 use Rapidez\Core\Facades\Rapidez;
+use Rapidez\Statamic\Commands\ImportCategories;
 use Rapidez\Statamic\Extend\SitesLinkedToMagentoStores;
 use Rapidez\Statamic\Forms\JsDrivers\Vue;
 use Rapidez\Statamic\Http\Controllers\StatamicRewriteController;
@@ -33,6 +34,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
     public function boot()
     {
         $this
+            ->bootCommands()
             ->bootConfig()
             ->bootRoutes()
             ->bootViews()
@@ -43,6 +45,15 @@ class RapidezStatamicServiceProvider extends ServiceProvider
 
         Vue::register();
         Alternates::register();
+    }
+
+    public function bootCommands() : self
+    {
+        $this->commands([
+            ImportCategories::class
+        ]);
+
+        return $this;
     }
 
     public function bootConfig() : self
@@ -73,6 +84,12 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         Event::listen([GlobalSetSaved::class, GlobalSetDeleted::class], function() {
             Cache::forget('statamic-globals-'.Site::current()->handle());
         });
+
+        Event::listen('rapidez-statamic:category-entry-data', fn($category) => [
+                'title' => $category->name,
+                'slug'  => trim($category->url_key),
+            ]
+        );
 
         return $this;
     }


### PR DESCRIPTION
Multiple examples of usages are
```bash
# Most basic, import all categories in all sites
php artisan rapidez:statamic:import:categories --all

# Import all categories in the site with handle "default" only
php artisan rapidez:statamic:import:categories --all --site=default

# import select categories in multiple sites
php artisan rapidez:statamic:import:categories 5 8 9 category-url-key --site=default --site=another_site
```

If you have a custom blueprint and would like to add more data from the category you can do so by hooking into the `rapidez-statamic:category-entry-data` event 

```php
        Event::listen('rapidez-statamic:category-entry-data', fn($category) => [
                'description' => $category->description,
            ]
        );
```