### PR TITLE
Remove ambiguous keys from query to help runway figure itself out

### DIFF
--- a/src/Models/Brand.php
+++ b/src/Models/Brand.php
@@ -2,10 +2,10 @@
 
 namespace Rapidez\Statamic\Models;
 
-use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 use Statamic\Facades\Site;
 
 class Brand extends Model
@@ -19,17 +19,23 @@ class Brand extends Model
     protected static function booting()
     {
         static::addGlobalScope(function (Builder $builder) {
+            $renamedAdmin = DB::table('eav_attribute_option_value')
+                ->select(['value AS value_admin', 'option_id AS sub_option_id', 'store_id']);
+
+            $renamedStore = DB::table('eav_attribute_option_value')
+                ->select(['value AS value_store', 'option_id AS sub_option_id', 'store_id']);
+
             $builder
                 ->select('eav_attribute_option.option_id AS option_id')
                 ->addSelect('eav_attribute_option.sort_order')
-                ->addSelect('admin_value.value AS value_admin')
-                ->selectRaw('IFNULL(store_value.value, admin_value.value) AS value_store')
-                ->leftJoin('eav_attribute_option_value AS admin_value', function ($join) {
-                    $join->on('admin_value.option_id', '=', 'eav_attribute_option.option_id')
+                ->addSelect('value_admin')
+                ->selectRaw('IFNULL(value_store, value_admin) AS value_store')
+                ->leftJoinSub($renamedAdmin, 'admin_value', function ($join) {
+                    $join->on('admin_value.sub_option_id', '=', 'eav_attribute_option.option_id')
                          ->where('admin_value.store_id', 0);
                 })
-                ->leftJoin('eav_attribute_option_value AS store_value', function ($join) {
-                    $join->on('store_value.option_id', '=', 'eav_attribute_option.option_id')
+                ->leftJoinSub($renamedStore, 'store_value', function ($join) {
+                    $join->on('store_value.sub_option_id', '=', 'eav_attribute_option.option_id')
                          ->where('store_value.store_id', Site::selected()->attributes['magento_store_id']);
                 })
                 ->where('attribute_id', config('rapidez-statamic.runway.brand_attribute_id'));


### PR DESCRIPTION
Runway crafts queries that don't take into account the possibility of having a query like this. For example, it assumes that the primary key is unique and doesn't need to be qualified.

By adding these subqueries we can rename the ambiguous keys before they become a problem.