### PR TITLE
Retrieve data from the actual current site

### DIFF
--- a/src/Models/Brand.php
+++ b/src/Models/Brand.php
@@ -36,7 +36,7 @@ class Brand extends Model
                 })
                 ->leftJoinSub($renamedStore, 'store_value', function ($join) {
                     $join->on('store_value.sub_option_id', '=', 'eav_attribute_option.option_id')
-                         ->where('store_value.store_id', Site::selected()->attributes['magento_store_id']);
+                         ->where('store_value.store_id', Site::current()->attributes['magento_store_id']);
                 })
                 ->where('attribute_id', config('rapidez.statamic.runway.brand_attribute_id'));
         });

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -14,6 +14,6 @@ class Category extends Model
 
     public function getTable()
     {
-        return 'catalog_category_flat_store_'.Site::selected()->attributes['magento_store_id'];
+        return 'catalog_category_flat_store_'.Site::current()->attributes['magento_store_id'];
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -23,6 +23,6 @@ class Product extends Model
 
     public function getTable()
     {
-        return 'catalog_product_flat_'.Site::selected()->attributes['magento_store_id'];
+        return 'catalog_product_flat_'.Site::current()->attributes['magento_store_id'];
     }
 }


### PR DESCRIPTION
The problem with using the selected() method is that it looks at your session to get the selected site in from CP like so:
`return $this->get(session('statamic.cp.selected-site')) ?? $this->default();`

This is why it would default to look in the default site on the frontend. Using the current() method fixes this as this is the method intended for the frontend.