### PR TITLE
Fix view caching by loading correctly scoped select input

### DIFF
--- a/resources/views/form_fields/select.blade.php
+++ b/resources/views/form_fields/select.blade.php
@@ -1,4 +1,4 @@
-<x-select
+<x-rapidez::select
     :name="$field['handle']"
     :label="$field['display']"
     :value="$field['old'] ?: $field['default'] ?? ''"
@@ -16,4 +16,4 @@
             {{ $label }}
         </option>
     @endforeach
-</x-select>
+</x-rapidez::select>


### PR DESCRIPTION
x-select is not a blade component, thus view caching fails and cannot finish if this package is installed.
This resolves it