### PR TITLE
Fix Rapidez Statamic config file path in Laravel config helper

### DIFF
--- a/src/Commands/ImportBrands.php
+++ b/src/Commands/ImportBrands.php
@@ -32,8 +32,8 @@ class ImportBrands extends Command
             foreach (Brand::get() as $brand) {
                 $statamicEntryAction::createEntry(
                     [
-                        'collection' => config('rapidez-statamic.import.brands.collection', 'brands'),
-                        'blueprint' => config('rapidez-statamic.import.brands.blueprint', 'brand'),
+                        'collection' => config('rapidez.statamic.import.brands.collection', 'brands'),
+                        'blueprint' => config('rapidez.statamic.import.brands.blueprint', 'brand'),
                         'site' => $site->handle(),
                         'linked_brand' => $brand->option_id,
                     ],

--- a/src/Commands/ImportCategories.php
+++ b/src/Commands/ImportCategories.php
@@ -60,8 +60,8 @@ class ImportCategories extends Command
             foreach ($categories as $category) {
                 $statamicEntryAction::createEntry(
                     [
-                        'collection' => config('rapidez-statamic.import.categories.collection', 'categories'),
-                        'blueprint'  => config('rapidez-statamic.import.categories.blueprint', 'category'),
+                        'collection' => config('rapidez.statamic.import.categories.collection', 'categories'),
+                        'blueprint'  => config('rapidez.statamic.import.categories.blueprint', 'category'),
                         'site'       => $site->handle(),
                         'linked_category' => $category->entity_id,
                     ],

--- a/src/Commands/ImportProducts.php
+++ b/src/Commands/ImportProducts.php
@@ -45,8 +45,8 @@ class ImportProducts extends Command
             foreach ($products as $product) {
                 $statamicEntryAction::createEntry(
                     [
-                        'collection' => config('rapidez-statamic.import.products.collection', 'products'),
-                        'blueprint'  => config('rapidez-statamic.import.products.blueprint', 'product'),
+                        'collection' => config('rapidez.statamic.import.products.collection', 'products'),
+                        'blueprint'  => config('rapidez.statamic.import.products.blueprint', 'product'),
                         'site'       => $site->handle(),
                         'linked_product' => $product->sku,
                     ],


### PR DESCRIPTION
The statamic.php config file has been moved in #44 but the command is still using the old path. This PR updates the old path to the new one.