### PR TITLE
Guarantee includeFirstSafe recieves array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.0|^8.1",
         "doublethreedigital/runway": "^5.0",
-        "rapidez/blade-directives": "^0.3",
+        "rapidez/blade-directives": "^0.4",
         "spatie/statamic-responsive-images": "^4.0",
         "statamic/cms": "^4.0",
         "tormjens/eventy": "^0.8"

--- a/resources/views/page_builder/form.blade.php
+++ b/resources/views/page_builder/form.blade.php
@@ -28,7 +28,7 @@
                     ])
                     v-if="{!! $form['show_field'][$field['handle']] ?? true !!}"
                 >
-                    @includeFirstSafe(['form_fields.' . $field['type'], 'rapidez-statamic::form_fields.' . $field['type']], $set)
+                    @includeFirstSafe(['form_fields.' . $field['type'], 'rapidez-statamic::form_fields.' . $field['type']], optionalDeep($set)->toArray())
                 </div>
             @endforeach
         </div>


### PR DESCRIPTION
Laravel includes only accept array as parameters for the view files.
Depending on nesting $set is an optionalDeep instance or an array already.
This way we are safe for both cases.