### PR TITLE
Add @tags directive (and fix some styling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,47 @@ Eventy::addFilter('rapidez.statamic.brand.entry.data', fn($brand) => [
 );
 ```
 
+### Blade directives
+
+#### @tags
+
+This package adds a Laravel Blade directive that can be used to make usage of the Statamic::tag functionality more concise. This directive can be used as such:
+
+```blade
+@tags(['collection:products', 'taxonomy:types'])
+```
+
+This will give you camelCased variables called `$collectionProducts` and `$taxonomyTypes` that can then be used in your blade file.
+
+You can also define your own variable names and send some params through, like this:
+
+```blade
+@tags([
+    'products' => 'collection:products',
+    'types' => ['taxonomy:types' => ['color:is' => 'red']],
+])
+```
+
+And if you only want one tag with the camelCased name, you can ditch the array:
+
+```blade
+@tags('collection:products')
+```
+
+Finally, if you prefer having some explicitly named key/value pairs, you can even do this:
+
+```blade
+@tags([
+    'products' => [
+        'tag' => 'collection:products',
+    ],
+    'types' => [
+        'tag' => 'taxonomy:types',
+        'params' => ['color:is' => 'red'],
+    ],
+])
+```
+
 ### Forms
 
 When you create a form you could use `rapidez-statamic::emails.form` as HTML template which uses the [Laravel mail template](https://laravel.com/docs/master/mail#customizing-the-components) with all fields in a table, make sure you enable markdown!

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -10,9 +10,10 @@ use Statamic\Facades\Utility;
 use Illuminate\Routing\Router;
 use Rapidez\Core\Facades\Rapidez;
 use Statamic\Events\GlobalSetSaved;
-use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\View;
 use Rapidez\Statamic\Tags\Alternates;
 use Statamic\Events\GlobalSetDeleted;
 use Illuminate\Support\ServiceProvider;
@@ -34,6 +35,8 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         $this->app->extend(Sites::class, function () {
             return new SitesLinkedToMagentoStores(config('statamic.sites'));
         });
+
+        $this->registerDirectives();
     }
 
     public function boot()
@@ -54,7 +57,42 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         Alternates::register();
     }
 
-    public function bootCommands() : self
+    public function registerDirectives(): static
+    {
+        Blade::directive('tags', function ($expression) {
+            /**
+             * Use Statamic::tag() in a more convenient way
+             * Usage:
+             *  - @tags(['products' => ['collection:products' => ['type' => 'chair']]])
+             *  - @tags(['products' => 'collection:products'])
+             *  - @tags('collection:products')
+             * etc...
+             */
+            return "<?php
+                foreach (Arr::wrap($expression) as \$__key => \$__value) {
+                    if (is_array(\$__value) && in_array('tag', \$__value)) {
+                        \$__tag = \$__value['tag'];
+                        \$__params = \$__value['params'] ?? [];
+                    } else if (is_array(\$__value) && count(\$__value) == 1) {
+                        \$__tag = array_keys(\$__value)[0];
+                        \$__params = array_values(\$__value)[0];
+                    } else if (is_string(\$__value)) {
+                        \$__tag = \$__value;
+                        \$__params = [];
+                    } else {
+                        continue;
+                    }
+                    \$__varName = is_string(\$__key) ? \$__key : camel_case(str_replace(':', '_', \$__tag));
+                    \${\$__varName} = Statamic::tag(\$__tag)->params(\$__params)->fetch();
+                }
+                unset(\$__tag, \$__params, \$__varName, \$__key, \$__value);
+            ?>";
+        });
+
+        return $this;
+    }
+
+    public function bootCommands(): static
     {
         $this->commands([
             ImportCategories::class,
@@ -65,14 +103,14 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootConfig() : self
+    public function bootConfig(): static
     {
         $this->mergeConfigFrom(__DIR__.'/../config/rapidez/statamic.php', 'rapidez.statamic');
 
         return $this;
     }
 
-    public function bootRoutes() : self
+    public function bootRoutes(): static
     {
         if (config('rapidez.statamic.routes') && $this->currentSiteIsEnabled()) {
             Rapidez::addFallbackRoute(StatamicRewriteController::class);
@@ -81,7 +119,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootViews() : self
+    public function bootViews(): static
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'rapidez-statamic');
         $this->loadViewsFrom(__DIR__.'/../resources/views/vendor/responsive-images', 'responsive-images');
@@ -89,7 +127,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootListeners() : self
+    public function bootListeners(): static
     {
         if ($this->currentSiteIsEnabled()) {
             Event::listen([GlobalSetSaved::class, GlobalSetDeleted::class], function () {
@@ -115,7 +153,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootRunway() : self
+    public function bootRunway(): static
     {
         if (config('rapidez.statamic.runway.configure') && $this->currentSiteIsEnabled()) {
             config(['runway.resources' => array_merge(
@@ -127,7 +165,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootComposers() : self
+    public function bootComposers(): static
     {
         if (config('rapidez.statamic.fetch.product') && $this->currentSiteIsEnabled()) {
             View::composer('rapidez::product.overview', function (RenderedView $view) {
@@ -161,7 +199,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootPublishables() : self
+    public function bootPublishables(): static
     {
         $this->publishes([
             __DIR__.'/../resources/blueprints/collections' => resource_path('blueprints/collections'),
@@ -181,7 +219,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootUtilities() : static
+    public function bootUtilities(): static
     {
         Utility::extend(function () : void {
             Utility::register('imports')
@@ -205,7 +243,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function bootStack() : static
+    public function bootStack(): static
     {
         View::startPush('head', view('rapidez-statamic::stack.head'));
 


### PR DESCRIPTION
Lets you use the `Statamic::tag()` function in a more convenient way, for example:

```blade
@tags([
    'types' => ['taxonomy:types' => ['color:is' => 'red']],
    'collection:pages',
])
```

Would give you two variables named `$types` and `$collectionPages` with the given statamic data.

See also [this PR](https://github.com/rapidez/blade-directives/pull/2). I don't know if this is really the right place either, as this would restrict this to Rapidez projects only while I seem to find the most benefits for this in non-rapidez Statamic projects.