### PR TITLE
Use the selected site in the control panel

### DIFF
--- a/src/Models/Brand.php
+++ b/src/Models/Brand.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Statamic\Facades\Site;
+use Statamic\Statamic;
 
 class Brand extends Model
 {
@@ -36,7 +37,7 @@ class Brand extends Model
                 })
                 ->leftJoinSub($renamedStore, 'store_value', function ($join) {
                     $join->on('store_value.sub_option_id', '=', 'eav_attribute_option.option_id')
-                         ->where('store_value.store_id', Site::current()->attributes['magento_store_id']);
+                         ->where('store_value.store_id', (Statamic::isCpRoute() ? Site::selected()->attributes['magento_store_id'] : Site::current()->attributes['magento_store_id']));
                 })
                 ->where('attribute_id', config('rapidez.statamic.runway.brand_attribute_id'));
         });

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -5,6 +5,7 @@ namespace Rapidez\Statamic\Models;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Facades\Site;
+use Statamic\Statamic;
 
 class Category extends Model
 {
@@ -14,6 +15,6 @@ class Category extends Model
 
     public function getTable()
     {
-        return 'catalog_category_flat_store_'.Site::current()->attributes['magento_store_id'];
+        return 'catalog_category_flat_store_'.(Statamic::isCpRoute() ? Site::selected()->attributes['magento_store_id'] : Site::current()->attributes['magento_store_id']);
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Facades\Site;
+use Statamic\Statamic;
 
 class Product extends Model
 {
@@ -23,6 +24,6 @@ class Product extends Model
 
     public function getTable()
     {
-        return 'catalog_product_flat_'.Site::current()->attributes['magento_store_id'];
+        return 'catalog_product_flat_' . (Statamic::isCpRoute() ? Site::selected()->attributes['magento_store_id'] : Site::current()->attributes['magento_store_id']);
     }
 }


### PR DESCRIPTION
When switching sites in the backend this didn't change the products listed in runway. This fixes that and keeps current functionality working