### PR TITLE
Implement performance optimizations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "justbetter/statamic-eloquent-driver-globalset-migration-generator": "^0.1.0",
         "rapidez/blade-directives": "^0.6",
         "justbetter/statamic-glide-directive": "^2.1",
+        "spatie/once": "*",
         "statamic-rad-pack/runway": "^7.6",
         "statamic/cms": "^5.0",
         "statamic/eloquent-driver": "^4.9",

--- a/src/Extend/SitesLinkedToMagentoStores.php
+++ b/src/Extend/SitesLinkedToMagentoStores.php
@@ -2,7 +2,7 @@
 
 namespace Rapidez\Statamic\Extend;
 
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Collection;
 use Statamic\Sites\Sites;
 
 class SitesLinkedToMagentoStores extends Sites
@@ -19,9 +19,9 @@ class SitesLinkedToMagentoStores extends Sites
 
     public function findByMageRunCode($code)
     {
-        if (!$code) {
+        if (!$code || !($this->sites instanceof Collection)) {
             return null;
         }
-        return Cache::store('array')->rememberForever('rapidez.statamic.findByMageRunCode-'.$code, fn() => collect($this->sites)->get($code));
+        return $this->sites->get($code));
     }
 }

--- a/src/Extend/SitesLinkedToMagentoStores.php
+++ b/src/Extend/SitesLinkedToMagentoStores.php
@@ -9,11 +9,11 @@ class SitesLinkedToMagentoStores extends Sites
 {
     public function findByUrl($url)
     {
-        if ($site = $this->findByMageRunCode(request()->server('MAGE_RUN_CODE'))) {
+        if ($site = once(fn() => $this->findByMageRunCode(request()->server('MAGE_RUN_CODE')))) {
             return $site;
         }
 
-        return Cache::store('array')->rememberForever('rapidez.statamic.findByUrl-'.$url, fn() => parent::findByUrl($url));
+        return once(fn() => parent::findByUrl($url));
     }
 
 

--- a/src/Extend/SitesLinkedToMagentoStores.php
+++ b/src/Extend/SitesLinkedToMagentoStores.php
@@ -2,6 +2,7 @@
 
 namespace Rapidez\Statamic\Extend;
 
+use Illuminate\Support\Facades\Cache;
 use Statamic\Sites\Sites;
 
 class SitesLinkedToMagentoStores extends Sites
@@ -12,12 +13,15 @@ class SitesLinkedToMagentoStores extends Sites
             return $site;
         }
 
-        return parent::findByUrl($url);
+        return Cache::store('array')->rememberForever('rapidez.statamic.findByUrl-'.$url, fn() => parent::findByUrl($url));
     }
 
 
     public function findByMageRunCode($code)
     {
-        return collect($this->sites)->get($code);
+        if (!$code) {
+            return null;
+        }
+        return Cache::store('array')->rememberForever('rapidez.statamic.findByMageRunCode-'.$code, fn() => collect($this->sites)->get($code));
     }
 }

--- a/src/Http/ViewComposers/StatamicGlobalDataComposer.php
+++ b/src/Http/ViewComposers/StatamicGlobalDataComposer.php
@@ -31,7 +31,7 @@ class StatamicGlobalDataComposer
     public function compose(View $view) : View
     {
         if (!$this->globals) {
-            $this->globals = optionalDeep((object)$this->getGlobals());
+            $this->globals = Cache::driver('array')->rememberForever('rapidez.statamic.globals', fn() => optionalDeep((object)$this->getGlobals()));
         }
         
         if (!isset($view->globals)) {

--- a/src/Http/ViewComposers/StatamicGlobalDataComposer.php
+++ b/src/Http/ViewComposers/StatamicGlobalDataComposer.php
@@ -31,7 +31,7 @@ class StatamicGlobalDataComposer
     public function compose(View $view) : View
     {
         if (!$this->globals) {
-            $this->globals = Cache::driver('array')->rememberForever('rapidez.statamic.globals', fn() => optionalDeep((object)$this->getGlobals()));
+            $this->globals = optionalDeep((object)$this->getGlobals());
         }
         
         if (!isset($view->globals)) {

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -15,6 +15,6 @@ class Category extends Model
 
     public function getTable()
     {
-        return 'catalog_category_flat_store_'.(Statamic::isCpRoute() ? (Site::selected()->attributes['magento_store_id'] ?? '1') : (Site::current()->attributes['magento_store_id'] ?? '1'));
+        return 'catalog_category_flat_store_'.once(fn() => (Statamic::isCpRoute() ? (Site::selected()->attributes['magento_store_id'] ?? '1') : (Site::current()->attributes['magento_store_id'] ?? '1')));
     }
 }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -15,6 +15,8 @@ class Category extends Model
 
     public function getTable()
     {
-        return 'catalog_category_flat_store_'.once(fn() => (Statamic::isCpRoute() ? (Site::selected()->attributes['magento_store_id'] ?? '1') : (Site::current()->attributes['magento_store_id'] ?? '1')));
+        return 'catalog_category_flat_store_'.once(fn() => (Statamic::isCpRoute()
+            ? (Site::selected()->attributes['magento_store_id'] ?? '1')
+            : (Site::current()->attributes['magento_store_id'] ?? '1')));
     }
 }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -15,8 +15,9 @@ class Category extends Model
 
     public function getTable()
     {
-        return 'catalog_category_flat_store_'.once(fn() => (Statamic::isCpRoute()
-            ? (Site::selected()->attributes['magento_store_id'] ?? '1')
-            : (Site::current()->attributes['magento_store_id'] ?? '1')));
+        return 'catalog_category_flat_store_'.once(fn() => (Statamic::isCpRoute() 
+            ? (Site::selected()->attributes['magento_store_id'] ?? '1') 
+            : (Site::current()->attributes['magento_store_id'] ?? '1')
+        ));
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -24,6 +24,8 @@ class Product extends Model
 
     public function getTable()
     {
-        return 'catalog_product_flat_' . once(fn() => (Statamic::isCpRoute() ? (Site::selected()->attributes['magento_store_id'] ?? '1') : Site::current()->attributes['magento_store_id'] ?? '1'));
+        return 'catalog_product_flat_' . once(fn() => (Statamic::isCpRoute()
+            ? (Site::selected()->attributes['magento_store_id'] ?? '1')
+            : Site::current()->attributes['magento_store_id'] ?? '1'));
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -26,6 +26,7 @@ class Product extends Model
     {
         return 'catalog_product_flat_' . once(fn() => (Statamic::isCpRoute()
             ? (Site::selected()->attributes['magento_store_id'] ?? '1')
-            : Site::current()->attributes['magento_store_id'] ?? '1'));
+            : (Site::current()->attributes['magento_store_id'] ?? '1')
+        ));
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -24,6 +24,6 @@ class Product extends Model
 
     public function getTable()
     {
-        return 'catalog_product_flat_' . (Statamic::isCpRoute() ? (Site::selected()->attributes['magento_store_id'] ?? '1') : Site::current()->attributes['magento_store_id'] ?? '1');
+        return 'catalog_product_flat_' . once(fn() => (Statamic::isCpRoute() ? (Site::selected()->attributes['magento_store_id'] ?? '1') : Site::current()->attributes['magento_store_id'] ?? '1'));
     }
 }


### PR DESCRIPTION
This implements an array cache to some often used functions.
Quick breakdown:
`FindByUrl` and by extension `findByMageRunCode` is getting hit `313` times.
On single store (or simply without the MAGE_RUN_CODE) this would result in 626 creations and lookups in a collection.
if the code is missing the `findByMageRunCode` cache is never created, thus the falsey check saves us on 313 lookups in case that header is missing. Otherwise we can assume the site will be found.

the casting of the large array of globals to object, and passing it to optionalDeep seems relatively heavy.
and it is executed `284` times (per view it is executed)
We cannot store it in Redis cache without breaking the object, thus array store is the best option here.