### PR TITLE
Automate sites.yaml config

### DIFF
--- a/config/rapidez/statamic.php
+++ b/config/rapidez/statamic.php
@@ -80,13 +80,10 @@ return [
 
     'sites' => [
         'default' => [
-            'name' => env('APP_NAME', 'Statamic'),
             'locale' => 'en_EN',
             'lang' => 'en_EN',
             'url' => '/',
             'attributes' => [
-                'magento_store_id' => 1,
-                'group' => 'default',
                 'disabled' => false,
             ],
         ],

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -42,6 +42,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         $this
             ->bootCommands()
             ->bootConfig()
+            ->bootSites()
             ->bootRoutes()
             ->bootViews()
             ->bootListeners()
@@ -53,6 +54,32 @@ class RapidezStatamicServiceProvider extends ServiceProvider
 
         Vue::register();
         Alternates::register();
+    }
+
+    public function bootSites() : self
+    {
+        $sites = [];
+        $stores = Rapidez::getStores();
+
+        foreach ($stores as $store) {
+            $sites[$store['code']] = [
+                'name' => $store['name'] ?? $store['code'],
+                'locale' => '{{ config:rapidez.statamic.sites.' . $store['code'] . '.locale }}',
+                'lang' => '{{ config:rapidez.statamic.sites.' . $store['code'] . '.lang }}',
+                'url' => '{{ config:rapidez.statamic.sites.' . $store['code'] . '.url }}',
+                'attributes' => [
+                    'magento_store_id' => $store['store_id'],
+                    'group' => $store['website_code'] ?? '',
+                    'disabled' => '{{ config:rapidez.statamic.sites.' . $store['code'] . '.attributes.disabled }}',
+                ]
+            ];
+//            dd($store, $sites);
+        }
+
+        Site::setSites($sites);
+        Site::save();
+
+        return $this;
     }
 
     public function bootCommands() : self

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -73,7 +73,6 @@ class RapidezStatamicServiceProvider extends ServiceProvider
                     'disabled' => '{{ config:rapidez.statamic.sites.' . $store['code'] . '.attributes.disabled }}',
                 ]
             ];
-//            dd($store, $sites);
         }
 
         Site::setSites($sites);

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Rapidez\Statamic;
 
-use Statamic\Statamic;
 use Statamic\Sites\Sites;
 use Statamic\Facades\Site;
 use Statamic\Facades\Entry;
@@ -33,7 +32,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->extend(Sites::class, function () {
-            return new SitesLinkedToMagentoStores(config('statamic.sites'));
+            return new SitesLinkedToMagentoStores();
         });
     }
 


### PR DESCRIPTION
We can automate the generation of the new sites.yaml.
By doing this we reduce the amount of config needed to configure the sites, only keeping a few settings in the sites array of `config/rapidez/statamic.php`.

Not sure yet if setting this during boot is the way to go, could also generate it through a command when setting up the site.
Let me know what you would prefer!