### PR TITLE
Hybrid Runway extended

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,12 @@
     "require": {
         "php": "^8.1|^8.2",
         "justbetter/statamic-eloquent-driver-globalset-migration-generator": "^0.1.0",
-        "rapidez/blade-directives": "^0.6",
         "justbetter/statamic-glide-directive": "^2.1",
-        "statamic-rad-pack/runway": "^7.6",
+        "rapidez/blade-directives": "^0.6",
+        "statamic-rad-pack/runway": "^7.11",
         "statamic/cms": "^5.0",
         "statamic/eloquent-driver": "^4.9",
+        "tdwesten/statamic-builder": "^1.0",
         "tormjens/eventy": "^0.8"
     },
     "autoload": {

--- a/config/rapidez/statamic/builder.php
+++ b/config/rapidez/statamic/builder.php
@@ -1,0 +1,11 @@
+<?php
+
+use Rapidez\Statamic\Collections\Categories;
+use Rapidez\Statamic\Collections\Products;
+
+return [
+    'collections' => [
+        Products::class,
+        Categories::class,
+    ]
+];

--- a/src/Collections/Categories.php
+++ b/src/Collections/Categories.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Rapidez\Statamic\Collections;
+
+use Statamic\Facades\Site;
+use Tdwesten\StatamicBuilder\BaseCollection;
+
+class Categories extends BaseCollection
+{
+    public static function handle(): string
+    {
+        return 'categories';
+    }
+
+    public function title(): string
+    {
+        return __('Categories');
+    }
+
+    public function route(): ?string
+    {
+        return null;
+    }
+
+    public function slugs(): bool
+    {
+        return true;
+    }
+
+    public function titleFormat(): null|string|array
+    {
+        return null;
+    }
+
+    public function mount(): ?string
+    {
+        return null;
+    }
+
+    public function date(): bool
+    {
+        return false;
+    }
+
+    public function sites(): array
+    {
+        return Site::all()->keys()->toArray();
+    }
+
+    public function template(): ?string
+    {
+        return null;
+    }
+
+    public function layout(): ?string
+    {
+        return null;
+    }
+
+    public function inject(): array
+    {
+        return [];
+    }
+
+    public function searchIndex(): string
+    {
+        return 'default';
+    }
+
+    public function revisionsEnabled(): bool
+    {
+        return false;
+    }
+
+    public function defaultPublishState(): bool
+    {
+        return true;
+    }
+
+    public function originBehavior(): string
+    {
+        return 'select';
+    }
+
+    public function structure(): ?array
+    {
+        return [
+            'root' => false,
+            'slugs' => false,
+            'max_depth' => 1
+        ];
+    }
+
+    public function sortBy(): ?string
+    {
+        return null;
+    }
+
+    public function sortDir(): ?string
+    {
+        return null;
+    }
+
+    public function taxonomies(): array
+    {
+        return [];
+    }
+
+    public function propagate(): ?bool
+    {
+        return null;
+    }
+
+    public function previewTargets(): array
+    {
+        return [];
+    }
+
+    public function autosave(): bool|int|null
+    {
+        return null;
+    }
+
+    public function futureDateBehavior(): ?string
+    {
+        return null;
+    }
+    public function pastDateBehavior(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Collections/Categories.php
+++ b/src/Collections/Categories.php
@@ -125,6 +125,7 @@ class Categories extends BaseCollection
     {
         return null;
     }
+    
     public function pastDateBehavior(): ?string
     {
         return null;

--- a/src/Collections/Products.php
+++ b/src/Collections/Products.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Rapidez\Statamic\Collections;
+
+use Statamic\Facades\Site;
+use Tdwesten\StatamicBuilder\BaseCollection;
+
+class Products extends BaseCollection
+{
+    public static function handle(): string
+    {
+        return 'products';
+    }
+
+    public function title(): string
+    {
+        return __('Products');
+    }
+
+    public function route(): ?string
+    {
+        return null;
+    }
+
+    public function slugs(): bool
+    {
+        return true;
+    }
+
+    public function titleFormat(): null|string|array
+    {
+        return null;
+    }
+
+    public function mount(): ?string
+    {
+        return null;
+    }
+
+    public function date(): bool
+    {
+        return false;
+    }
+
+    public function sites(): array
+    {
+        return Site::all()->keys()->toArray();
+    }
+
+    public function template(): ?string
+    {
+        return null;
+    }
+
+    public function layout(): ?string
+    {
+        return null;
+    }
+
+    public function inject(): array
+    {
+        return [];
+    }
+
+    public function searchIndex(): string
+    {
+        return 'default';
+    }
+
+    public function revisionsEnabled(): bool
+    {
+        return false;
+    }
+
+    public function defaultPublishState(): bool
+    {
+        return true;
+    }
+
+    public function originBehavior(): string
+    {
+        return 'select';
+    }
+
+    public function structure(): ?array
+    {
+        return [
+            'root' => false,
+            'slugs' => false,
+            'max_depth' => 1
+        ];
+    }
+
+    public function sortBy(): ?string
+    {
+        return null;
+    }
+
+    public function sortDir(): ?string
+    {
+        return null;
+    }
+
+    public function taxonomies(): array
+    {
+        return [];
+    }
+
+    public function propagate(): ?bool
+    {
+        return null;
+    }
+
+    public function previewTargets(): array
+    {
+        return [];
+    }
+
+    public function autosave(): bool|int|null
+    {
+        return null;
+    }
+
+    public function futureDateBehavior(): ?string
+    {
+        return null;
+    }
+    public function pastDateBehavior(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -17,8 +17,8 @@ class Category extends Model
     
     protected $primaryKey = 'entity_id';
 
-    public $linkField = 'linked_category';
-    public $collection = 'categories';
+    public string $linkField = 'linked_category';
+    public string  $collection = 'categories';
 
     public function getTable()
     {

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -2,16 +2,23 @@
 
 namespace Rapidez\Statamic\Models;
 
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Model;
+use Rapidez\Statamic\Models\Traits\HasContentEntry;
 use Statamic\Facades\Site;
 use Statamic\Statamic;
+use Rapidez\Statamic\Observers\RunwayObserver;
 
+#[ObservedBy([RunwayObserver::class])]
 class Category extends Model
 {
-    use HasRunwayResource;
+    use HasRunwayResource, HasContentEntry;
     
     protected $primaryKey = 'entity_id';
+
+    public $linkField = 'linked_category';
+    public $collection = 'categories';
 
     public function getTable()
     {

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -2,57 +2,32 @@
 
 namespace Rapidez\Statamic\Models;
 
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
-use StatamicRadPack\Runway\Support\Json;
+use Rapidez\Statamic\Collections\Products;
+use Rapidez\Statamic\Models\Traits\HasContentEntry;
+use Rapidez\Statamic\Observers\RunwayObserver;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
-use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Statamic;
 
+#[ObservedBy([RunwayObserver::class])]
 class Product extends Model
 {
-    use HasRunwayResource;
+    use HasRunwayResource, HasContentEntry;
     
     protected $primaryKey = 'sku';
     protected $keyType = 'string';
+    
+    public $linkField = 'linked_product';
+    public $collection = 'products';
 
     protected static function booting()
     {
         static::addGlobalScope(function (Builder $builder) {
             $builder->whereIn('visibility', config('rapidez.statamic.runway.product_visibility'));
         });
-
-        static::updating(function (Product $product) {
-            $productEntry = $product->entry;
-
-            if (!$productEntry) {
-                $productEntry = Entry::make()
-                    ->collection('products')
-                    ->locale(Site::selected()->handle())
-                    ->data(['linked_product' => $product->sku]);
-            }
-
-            $attributes = $product->getDirty();
-
-            foreach ($attributes as $key => $value) {
-                // Is there a way we can detect this earlier?
-                // So we know what's coming from for example
-                // the blueprint as it's defined there.
-                if (Json::isJson($value)) {
-                    $attributes[$key] = json_decode((string) $value, true);
-                }
-            }
-
-            $productEntry->merge($attributes)->save();
-
-            return false;
-        });
-
-        // Just to make sure you can't create or delete
-        static::creating(fn (Product $product) => false);
-        static::deleting(fn (Product $product) => false);
     }
 
     public function getTable()
@@ -61,32 +36,5 @@ class Product extends Model
             ? (Site::selected()->attributes['magento_store_id'] ?? '1')
             : (Site::current()->attributes['magento_store_id'] ?? '1')
         );
-    }
-
-    public function getAttributes()
-    {
-        parent::getAttributes();
-
-        // Had some issues with non-existing models and attributes,
-        // this fixed that but not sure yet if this is the way.
-        if ($this->exists && $entry = ($this->entry ?? '')) {
-            $this->attributes = array_merge(
-                $entry->data()->toArray(),
-                $this->attributes
-            );
-        }
-
-        return $this->attributes;
-    }
-
-    protected function entry(): Attribute
-    {
-        return Attribute::make(
-            get: fn () => Entry::query()
-                ->where('collection', 'products')
-                ->where('site', Site::selected()->handle())
-                ->where('linked_product', $this->sku)
-                ->first(),
-        )->shouldCache();
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -19,9 +19,9 @@ class Product extends Model
     
     protected $primaryKey = 'sku';
     protected $keyType = 'string';
-    
-    public $linkField = 'linked_product';
-    public $collection = 'products';
+
+    public string $linkField = 'linked_product';
+    public string $collection = 'products';
 
     protected static function booting()
     {

--- a/src/Models/Traits/HasContentEntry.php
+++ b/src/Models/Traits/HasContentEntry.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rapidez\Statamic\Models\Traits;
+
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Rapidez\Statamic\Observers\RunwayObserver;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+
+trait HasContentEntry
+{
+    public function getAttributes()
+    {
+        parent::getAttributes();
+
+        // Had some issues with non-existing models and attributes,
+        // this fixed that but not sure yet if this is the way.
+        if ($this->exists && $entry = ($this->entry ?? '')) {
+            $this->attributes = array_merge(
+                $entry->data()->toArray(),
+                $this->attributes
+            );
+        }
+
+        return $this->attributes;
+    }
+
+    protected function entry(): Attribute
+    {
+        return Attribute::make(
+            get: fn() => Entry::query()
+                ->where('collection', $this->collection)
+                ->where('site', Site::selected()->handle())
+                ->where($this->linkField, $this->{$this->getKeyName()})
+                ->first(),
+        )->shouldCache();
+    }
+}

--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rapidez\Statamic\Observers;
+
+use Illuminate\Database\Eloquent\Model;
+use StatamicRadPack\Runway\Support\Json;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+
+class RunwayObserver
+{
+    public function updating(Model $model)
+    {
+        $entry = $model->entry;
+    
+        if (!$entry) {
+            $entry = Entry::make()
+                ->collection($model->collection)
+                ->locale(Site::selected()->handle())
+                ->data([$model->linkField => $model->{$model->getKeyName()}]);
+        }
+        
+        $attributes = $model->getDirty();
+        
+        foreach ($attributes as $key => $value) {
+            // Is there a way we can detect this earlier?
+            // So we know what's coming from for example
+            // the blueprint as it's defined there.
+            if (Json::isJson($value)) {
+                $attributes[$key] = json_decode((string) $value, true);
+            }
+        }
+
+        $entry->merge($attributes);
+
+        // When we save via the facade we can bypass the auto generation 
+        // of title and slug, we want this because there's no blueprint 
+        // for the collection. We don't need this for now.
+        Entry::save($entry);
+
+        return false;
+    }
+
+    // Just to make sure you can't create or delete
+    public function creating(Model $product)
+    {
+        return false;
+    }
+
+    public function deleting(Model $product)
+    {
+        return false;
+    }
+}

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -49,10 +49,21 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             ->bootComposers()
             ->bootPublishables()
             ->bootUtilities()
-            ->bootStack();
+            ->bootStack()
+            ->bootBuilder();
 
         Vue::register();
         Alternates::register();
+    }
+    
+    protected function bootBuilder(): self
+    {
+        config(['statamic.builder' => [
+            ...(config('statamic.builder') ?? []),
+            ...config('rapidez.statamic.builder'),
+        ]]);
+
+        return $this;
     }
 
     public function bootCommands() : self
@@ -69,6 +80,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
     public function bootConfig() : self
     {
         $this->mergeConfigFrom(__DIR__.'/../config/rapidez/statamic.php', 'rapidez.statamic');
+        $this->mergeConfigFrom(__DIR__ . '/../config/rapidez/statamic/builder.php', 'rapidez.statamic.builder');
 
         return $this;
     }
@@ -95,11 +107,6 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             Event::listen([GlobalSetSaved::class, GlobalSetDeleted::class], function () {
                 Cache::forget('statamic-globals-' . Site::selected()->handle());
             });
-
-            Eventy::addFilter('rapidez.statamic.category.entry.data', fn($category) => [
-                'title' => $category->name,
-                'slug' => trim($category->url_key),
-            ]);
 
             Eventy::addFilter('rapidez.statamic.brand.entry.data', fn($brand) => [
                 'title' => $brand->value_store,
@@ -177,6 +184,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../config/rapidez/statamic.php' => config_path('rapidez/statamic.php'),
+            __DIR__ . '/../config/rapidez/statamic/builder.php' => config_path('rapidez/statamic/builder.php'),
         ], 'config');
 
         return $this;


### PR DESCRIPTION
This extends the functionality in #80 . It adds a trait for the linking of a content entry, also added the collections via Statamic builder. The trait uses 2 variables in the model to determine which collection is used and which field on it is used to link the content on. 
```php
    public string $linkField = 'linked_category';

    public string $collection = 'categories';
```

I also moved the model events to a observer so we can use it for multiple model types.

```php
#[ObservedBy([RunwayObserver::class])]
class Category extends Model
{
```
The only downside of using the Statamic builder package is it forces to use all the functions and we don't need them.

We still need to figure out a way to not display the "Content" collections in the CP.  I think we can manage it at https://github.com/tdwesten/statamic-builder/blob/main/src/Repositories/CollectionRepository.php . 

Also in some projects we use the brands collection routes. We still have to figure out a way to let that be possible, and persist the data already present. Let's discuss this.