### PR TITLE
Fix arrayable link

### DIFF
--- a/src/RapidezStatamic.php
+++ b/src/RapidezStatamic.php
@@ -54,9 +54,13 @@ class RapidezStatamic
         return $tree;
     }
 
-    public function determineEntryUrl(Entry|Page $entry, string $nav = 'global-link'): string
+    public function determineEntryUrl(Entry|Page|string $entry, string $nav = 'global-link'): string
     {
         $cacheKey = $nav . '-' . config('rapidez.store');
+
+        if (is_string($entry)) {
+            return $entry;
+        }
 
         if ( ! isset($this->navCache[$nav][$entry->id()])) {
             $linkedRunwayResourceKey = $entry


### PR DESCRIPTION
When using a link field the field will return an arrayable link. This will give you a string link when given a normal entry with a url using `->value()`. If you want to be linking entries and hybrid runway resources, we need this check instead of this check existing in templates.