### PR TITLE
Static caching with invalidation on Magento urls

### DIFF
--- a/src/Commands/InvalidateCacheCommand.php
+++ b/src/Commands/InvalidateCacheCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Rapidez\Statamic\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Rapidez\Core\Facades\Rapidez;
+use Statamic\StaticCaching\Cacher;
+
+class InvalidateCacheCommand extends Command
+{
+    protected $signature = 'rapidez-statamic:invalidate-cache';
+
+    protected $description = 'Search for invalidatable caches';
+
+    public $urls;
+
+    public $latestCheck;
+
+    public function handle(Cacher $cacher): void
+    {
+        $this->latestCheck = Cache::get($this->signature);
+
+        if (!$this->latestCheck) {
+            $this->info('Cleared all urls (as we do not have a latest check date yet)');
+            $this->setLatestCheckDate();
+            $cacher->flush();
+            return;
+        }
+
+        $this->setLatestCheckDate();
+        $stores = Rapidez::getStores();
+
+        foreach ($stores as $store) {
+            Rapidez::setStore($store);
+
+            $this->urls = collect();
+
+            $this
+                ->addProductsUrls()
+                ->addCategoryUrls()
+                ->addPageUrls()
+                ->makeAbsolute();
+
+            $cacher->invalidateUrls($this->urls);
+
+            foreach ($this->urls as $url) {
+                $this->line($url);
+            }
+
+            $this->info('Done invalidating');
+        }
+    }
+
+    protected function addProductsUrls(): self
+    {
+        $products = config('rapidez.models.product')::withoutGlobalScopes()
+            ->where('updated_at', '>=', $this->latestCheck)
+            ->with(['parent:entity_id' => ['rewrites']])
+            ->with('rewrites')
+            ->get('entity_id');
+
+        foreach ($products as $product) {
+            $this->addUrls($this->getUrlsFromRewrites($product->rewrites));
+
+            if ($product->parent) {
+                $this->addUrls($this->getUrlsFromRewrites($product->parent->rewrites));
+            }
+        }
+
+        return $this;
+    }
+
+    protected function addCategoryUrls(): self
+    {
+        $categories = config('rapidez.models.category')::withoutGlobalScopes()
+            ->where('updated_at', '>=', $this->latestCheck)
+            ->get('entity_id');
+
+        foreach ($categories as $category) {
+            $this->addUrls($this->getUrlsFromRewrites($category->rewrites));
+        }
+
+        return $this;
+    }
+
+    protected function addPageUrls(): self
+    {
+        $identifiers = config('rapidez.models.page')::query()
+            ->where('update_time', '>=', $this->latestCheck)
+            ->pluck('identifier');
+
+        $this->addUrls($identifiers);
+
+        return $this;
+    }
+
+    protected function addUrls($urls): self
+    {
+        $this->urls = $this->urls->merge($urls);
+
+        return $this;
+    }
+
+    protected function getUrlsFromRewrites($rewrites)
+    {
+        return $rewrites->map(fn ($rewrite) => $rewrite->request_path);
+    }
+
+    protected function makeAbsolute(): self
+    {
+        $this->urls->transform(fn ($identifier) => url($identifier));
+
+        return $this;
+    }
+
+    protected function setLatestCheckDate(): void
+    {
+        // With this we're just making sure the comparison
+        // is done within the same timezone in MySQL.
+        $now = DB::select('SELECT NOW() AS `current_time`');
+
+        Cache::forever($this->signature, $now[0]->current_time);
+    }
+}

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -2,33 +2,35 @@
 
 namespace Rapidez\Statamic;
 
-use Statamic\Sites\Sites;
-use Statamic\Facades\Site;
-use Statamic\Facades\Entry;
-use Statamic\Facades\Utility;
 use Illuminate\Routing\Router;
-use Rapidez\Core\Facades\Rapidez;
-use Statamic\Events\GlobalSetSaved;
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
-use Rapidez\Statamic\Tags\Alternates;
-use Statamic\Events\GlobalSetDeleted;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\View as RenderedView;
-use Rapidez\Statamic\Commands\InstallCommand;
+use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Statamic\Commands\ImportBrands;
-use Rapidez\Statamic\Commands\ImportProducts;
 use Rapidez\Statamic\Commands\ImportCategories;
-use Rapidez\Statamic\Forms\JsDrivers\Vue;
+use Rapidez\Statamic\Commands\ImportProducts;
+use Rapidez\Statamic\Commands\InstallCommand;
+use Rapidez\Statamic\Commands\InvalidateCacheCommand;
 use Rapidez\Statamic\Extend\SitesLinkedToMagentoStores;
+use Rapidez\Statamic\Forms\JsDrivers\Vue;
 use Rapidez\Statamic\Http\Controllers\ImportsController;
-use Statamic\Http\Controllers\FrontendController;
 use Rapidez\Statamic\Http\ViewComposers\StatamicGlobalDataComposer;
 use Rapidez\Statamic\Listeners\ClearNavTreeCache;
 use Rapidez\Statamic\Listeners\SetCollectionsForNav;
+use Rapidez\Statamic\Tags\Alternates;
+use Statamic\Events\GlobalSetDeleted;
+use Statamic\Events\GlobalSetSaved;
 use Statamic\Events\NavCreated;
 use Statamic\Events\NavTreeSaved;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+use Statamic\Facades\Utility;
+use Statamic\Http\Controllers\FrontendController;
+use Statamic\Sites\Sites;
+use Statamic\StaticCaching\Middleware\Cache as StaticCache;
 use TorMorten\Eventy\Facades\Eventy;
 
 class RapidezStatamicServiceProvider extends ServiceProvider
@@ -38,6 +40,11 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         $this->app->extend(Sites::class, fn () => new SitesLinkedToMagentoStores());
 
         $this->app->singleton(RapidezStatamic::class);
+
+        $this->app->booted(function () {
+            $router = app(Router::class);
+            $router->pushMiddlewareToGroup('web', StaticCache::class);
+        });
     }
 
     public function boot()
@@ -65,6 +72,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             ImportProducts::class,
             ImportBrands::class,
             InstallCommand::class,
+            InvalidateCacheCommand::class,
         ]);
 
         return $this;


### PR DESCRIPTION
It just adds the static caching middleware on the `web` middleware group, this way all urls can be cached. To invalidate changed pages the `rapidez-statamic:invalidate-cache` should be scheduled, all info will go into the docs later.

There are some todo's left:

- Docs
- Double check with multisites
- Optionally; cache warming

Ah and.. we could cherry pick this into 4.x if we want this in Rapidez v2 installations.