### PR TITLE
Use whereJsonContains

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -149,7 +149,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
                 $entry = Entry::query()
                     ->where('collection', 'products')
                     ->where('site', $this->getSiteHandleByStoreId())
-                    ->where('linked_product', config('frontend.product.sku'))
+                    ->whereJsonContains('linked_product', config('frontend.product.sku'))
                     ->first();
 
                 $view->with('content', optionalDeep($entry));
@@ -161,7 +161,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
                 $entry = Entry::query()
                     ->where('collection', 'categories')
                     ->where('site', $this->getSiteHandleByStoreId())
-                    ->where('linked_category', config('frontend.category.entity_id'))
+                    ->whereJsonContains('linked_category', config('frontend.category.entity_id'))
                     ->first();
 
                 $view->with('content', optionalDeep($entry));


### PR DESCRIPTION
The `linked_product` and `linked_category` fields are a "Belongs To" field which is one of those fields that always has `max_items:1`. Normally, when you would save an entry, this field would just return the number, like so:

```js
{
    ...
    linked_category:92
    ...
}
```

However, since a semi-recent update of runway, if you save the blueprint, it will silently remove "max_items:1" from the field, and you end up getting this:

```js
{
    ...
    linked_category:[92]
    ...
}
```

This is sort of a bug, or at least an unintended side effect of some update.

---

This is a backwards-compatible way to make sure this update doesn't break your links. Whether or not this is the ideal solution, I'm not sure. Ideally this bug should just get fixed of course 🙂 