### PR TITLE
Get site by Store ID fix

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -248,9 +248,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
     public function getSiteHandleByStoreId(): string
     {
         $site = Site::all()
-            ->filter(fn($_site) => 
-                ($_site?->attributes()['magento_store_id'] ?? false) &&
-                ((int) $_site?->attributes()['magento_store_id'] === (int) config('rapidez.store')))
+            ->filter(fn($_site) => ($_site?->attributes()['magento_store_id'] ?? null) == config('rapidez.store'))
             ->first();
 
         return $site?->handle() ?? config('rapidez.store_code');

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -248,7 +248,9 @@ class RapidezStatamicServiceProvider extends ServiceProvider
     public function getSiteHandleByStoreId(): string
     {
         $site = Site::all()
-            ->filter(fn($_site) => ($_site?->attributes()['magento_store_id'] ?? null) === config('rapidez.store'))
+            ->filter(fn($_site) => 
+            ($_site?->attributes()['magento_store_id'] ?? false) &&
+            ((int) $_site?->attributes()['magento_store_id'] === (int) config('rapidez.store')))
             ->first();
 
         return $site?->handle() ?? config('rapidez.store_code');

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -249,8 +249,8 @@ class RapidezStatamicServiceProvider extends ServiceProvider
     {
         $site = Site::all()
             ->filter(fn($_site) => 
-            ($_site?->attributes()['magento_store_id'] ?? false) &&
-            ((int) $_site?->attributes()['magento_store_id'] === (int) config('rapidez.store')))
+                ($_site?->attributes()['magento_store_id'] ?? false) &&
+                ((int) $_site?->attributes()['magento_store_id'] === (int) config('rapidez.store')))
             ->first();
 
         return $site?->handle() ?? config('rapidez.store_code');


### PR DESCRIPTION
In some cases there is a problem in the way the `magento_store_id` attribute in the sites.yaml is being parsed through antlers.
When getting the attribute from the site the store ID is not always being cast as an integer but as a string.

![Screenshot 2024-12-12 at 10 52 14](https://github.com/user-attachments/assets/6725535d-dd28-4c91-8257-9e4005b8af79)

I've made some changes to cast this as an integer.
