### PR TITLE
Fixed public url for statamic sitemaps

### DIFF
--- a/src/Jobs/GenerateStoreSitemapJob.php
+++ b/src/Jobs/GenerateStoreSitemapJob.php
@@ -74,7 +74,7 @@ class GenerateStoreSitemapJob implements ShouldQueue, ShouldBeUnique
         $sitemaps = collect($storageDisk->files($storageDirectory))
             ->filter(fn($item) => str_starts_with($item, $storageDirectory . $sitemapPrefix))
             ->map(fn($item) => [
-                'loc' => url($item),
+                'loc' => url('storage/' . $item),
                 'lastmod' => $storageDisk->lastModified($item)
                     ? date('Y-m-d H:i:s', $storageDisk->lastModified($item))
                     : null


### PR DESCRIPTION
Had to prefix the url with `storage/` as the Statamic sitemaps weren't available on `/rapidez-sitemaps/1/statamic_sitemap_collection_pages.xml` but actually on `/storage/rapidez-sitemaps/1/statamic_sitemap_collection_pages.xml`.