### PR TITLE
[4.x] Reduce queries

### DIFF
--- a/src/Eloquent/Assets/AssetRepository.php
+++ b/src/Eloquent/Assets/AssetRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rapidez\Statamic\Eloquent\Assets;
+
+use Illuminate\Support\Facades\Cache;
+use Statamic\Contracts\Assets\Asset as AssetContract;
+use Statamic\Support\Str;
+use Statamic\Eloquent\Assets\AssetRepository as StatamicAssetRepository;
+
+class AssetRepository extends StatamicAssetRepository
+{
+    public function findById($id): ?AssetContract
+    {
+        [$container, $path] = explode('::', $id);
+
+        $filename = Str::afterLast($path, '/');
+        $folder = Str::contains($path, '/') ? Str::beforeLast($path, '/') : '/';
+
+        $cacheKey = "eloquent-asset-{$id}";
+
+        return Cache::rememberForever($cacheKey, function () use ($container, $filename, $folder) {
+            return $this->query()
+                ->where('container', $container)
+                ->where('folder', $folder)
+                ->where('basename', $filename)
+                ->first();
+        });
+    }
+}

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rapidez\Statamic\Fieldtypes\Assets;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Statamic\Assets\OrderedQueryBuilder;
+use Statamic\Fieldtypes\Assets\Assets as StatamicAssets;
+
+class Assets extends StatamicAssets
+{
+    public function augment($values)
+    {
+        $values = Arr::wrap($values);
+
+        $single = $this->config('max_files') === 1;
+
+        if ($single && Cache::has($key = 'assets-augment-' . json_encode($values))) {
+            return Cache::get($key);
+        }
+
+        $ids = collect($values)
+            ->map(fn($value) => $this->container()->handle() . '::' . $value)
+            ->all();
+
+        $query = $this->container()->queryAssets()->whereIn('path', $values);
+
+        $query = new OrderedQueryBuilder($query, $ids);
+
+        return $single && ! config('statamic.system.always_augment_to_query', false)
+            ? Cache::rememberForever($key, fn() => $query->first())
+            : $query;
+    }
+}

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rapidez\Statamic\View;
+
+use Statamic\View\Cascade as StatamicCascade;
+
+class Cascade extends StatamicCascade
+{
+    protected function hydrateGlobals()
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
This PR adds some Statamic overwrites. It disables the hydration of globals as we're doing that ourselves. It also puts the meta query's for assets in the Cache. Sadly Statamic uses this logic in the control panel so we do need to execute it. By putting it in the Cache store instead of in Blink it reduces the queries on the frontend hugely.

Before these changes:
![Scherm­afbeelding 2024-12-24 om 10 35 25](https://github.com/user-attachments/assets/6fee2bc5-f86c-47cc-9aee-5de952a72a66)


After these changes:
![Scherm­afbeelding 2024-12-24 om 10 36 33](https://github.com/user-attachments/assets/57d53940-ba04-407c-a9f5-9f64904d41cc)

I'll put this as a draft to have it open for discussion, we can add this for 5.x later when necessary.