### PR TITLE
[4.x] Change cache key for nav tree

### DIFF
--- a/src/RapidezStatamic.php
+++ b/src/RapidezStatamic.php
@@ -21,7 +21,7 @@ class RapidezStatamic
             'You can only use a nav tag to get a navigation tree.'
         );
 
-        return Cache::rememberForever($tag . '-' . config('rapidez.store'), fn() => $this->buildMenu($tag));
+        return Cache::rememberForever($tag . '-tree-' . config('rapidez.store'), fn() => $this->buildMenu($tag));
     }
 
     protected function buildMenu(string $key): array


### PR DESCRIPTION
This cache key clashed with the one used for `navCache` below. This caused it to sometimes (but not always) throw a 500 error after a cache clear.