### PR TITLE
[5.x] Automaticly set the config of the static caching paths when enabled

### DIFF
--- a/src/Extend/SitesLinkedToMagentoStores.php
+++ b/src/Extend/SitesLinkedToMagentoStores.php
@@ -32,6 +32,7 @@ class SitesLinkedToMagentoStores extends Sites
         return Cache::rememberForever('statamic_sites', function () {
             $sites = [];
             $stores = Rapidez::getStores();
+            $staticPaths = collect();
             $configModel = config('rapidez.models.config');
 
             foreach ($stores as $store) {
@@ -55,7 +56,13 @@ class SitesLinkedToMagentoStores extends Sites
                         'group' => $store['website_code'] ?? ''
                     ]
                 ];
+
+                if (config('statamic.static_caching.strategy') === 'full') {
+                    $staticPaths->put($store['code'], public_path('static') . '/' . str($url)->replace('https://', '')->replaceLast('/', '')->value());
+                }
             }
+            
+            config(['statamic.static_caching.strategies.full.path' => $staticPaths->toArray()]);
 
             return $sites ?: $this->getFallbackConfig();
         });


### PR DESCRIPTION
If we're automaticly setting the statamic sites we can also set the static caching paths. This way we don't need the urls in the `.env` when using static caching.