### PR TITLE
[4.x] Reload csrf token when statamic reloads it

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,3 +1,7 @@
 import 'Vendor/rapidez/core/resources/js/vue'
 
 Vue.component('form-conditions', () => import('./components/FormConditions.vue'));
+
+document.addEventListener('statamic:nocache.replaced', (e) => {
+    window.app.csrfToken = e?.detail?.csrf ?? window.app.csrfToken
+})


### PR DESCRIPTION
Whenever Static caching is used, Statamic updates the CSRF token however our vue propery is not yet updated. This add's the functionality that the vue property get's refreshed also.