### PR TITLE
[4.x] Return if url path is not set on the linked entry

### DIFF
--- a/src/RapidezStatamic.php
+++ b/src/RapidezStatamic.php
@@ -77,6 +77,12 @@ class RapidezStatamic
                 default => '',
             };
 
+            if (!isset($entry->{$linkedRunwayResourceKey}['url_path'])) {
+                $this->navCache[$nav][$entry->id()] = '';
+                
+                return '';
+            }
+
             $this->navCache[$nav][$entry->id()] = '/' . $entry->{$linkedRunwayResourceKey}['url_path'] . $suffix;
             
             Cache::forever($cacheKey, $this->navCache[$nav]);


### PR DESCRIPTION
Some projects we have use an empty link item to have a heading above other links. When this is used the `url_path` on the linked runway resource is not present. This adds a early return for that.

5.x: #106 