### PR TITLE
Fixed infinite locking for certain requests

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Rapidez\Statamic;
 
+use Illuminate\Foundation\Bootstrap\BootProviders;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
@@ -48,6 +49,11 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         $this->app->booted(function () {
             $router = app(Router::class);
             $router->pushMiddlewareToGroup('web', StaticCache::class);
+        });
+        $this->app->afterBootstrapping(BootProviders::class, function () {
+            // Prevent infinite locks by removing the static cache from the statamic.web middleware.
+            $router = app(Router::class);
+            $router->removeMiddlewareFromGroup('statamic.web', StaticCache::class);
         });
     }
 


### PR DESCRIPTION
Because of the locking implemented in https://github.com/statamic/cms/blob/8a2ad86a7b7ad8a76c37db3ee3ff71ecbad45627/src/StaticCaching/Middleware/Cache.php#L59
running this middleware twice will force it to lock forever:

1. First time calling the function in: create the lock until i get my response, call the next middleware in the chain
2. Second time calling the middleware: There is a lock active for this request, i must wait for that to release before proceeding to the next middleware.

This will cause an infinite wait time.
As the web middleware group will always be applied we can remove the middleware from the statamic.web middleware group