### PR TITLE
Do startPush on view composer instead of boot

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -242,9 +242,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
 
     public function bootStack() : static
     {
-        if (! $this->app->runningInConsole()) {
-            View::startPush('head', view('statamic-glide-directive::partials.head'));
-        }
+        View::composer('rapidez::layouts.app', fn($view) => $view->getFactory()->startPush('head', view('statamic-glide-directive::partials.head')));
 
         return $this;
     }


### PR DESCRIPTION
Alternative of: https://github.com/rapidez/core/pull/701

The issue arises when we get an error while attempting to render a page, e.g. a 404. Here's a play by play of what happens:

1. A user navigates to a nonexistent page that will throw a 404
2. The app boots
3. The pipelines and controllers all happen, eventually arriving at Statamic's frontendcontroller which tries to find a page
4. Statamic renders a view, fails, and throws a 404
5. The Laravel Pipeline catches this error and goes on to render a 404 page. Critically, this doesn't re-boot the app because it has already booted.

Note that both step 4 and step 5 render a view, and also note that when a view gets rendered, it will flush the stacks. Ultimately, this means that when you get a 404 page, this startPush has been consumed by Statamic and will not actually push to the final page render.

*EDIT: Note also that there may definitely be other cases where more than one view gets rendered per boot. I couldn't give you any concrete examples, but I would not be surprised if there are legitimate use cases for that.*

---

The above PR to the Rapidez core fixes the stack flush at step 4 by tricking Laravel into expecting a JSON response.  
The PR you're looking at right now makes it so the stack gets pushed to whenever the view is rendered.