### PR TITLE
Refactored install command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "justbetter/statamic-glide-directive": "^2.1",
         "rapidez/blade-directives": "^1.0",
         "rapidez/core": "^2.13|^3.0",
-        "rapidez/sitemap": "^1.1",
+        "rapidez/sitemap": "^3.0",
         "spatie/once": "*",
         "statamic-rad-pack/runway": "^7.6",
         "statamic/cms": "^5.29",

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -78,17 +78,11 @@ class InstallCommand extends Command
         $this->info('Starting User Setup...');
         $authConfig = config_path('auth.php');
 
-        if (!class_exists('\App\Models\User') && file_exists($authConfig) && config('auth.providers.users.model') !== 'Rapidez\Statamic\Models\User') {
-            $authFile = Str::of(File::get($authConfig));
-            $authFile = $authFile->replace(
-                'App\Models\User::class',
-                '\Rapidez\Statamic\Models\User::class'
-            );
-
-            File::put(
-                $authConfig,
-                $authFile->__toString()
-            );
+        if (!class_exists('\App\Models\User') && file_exists($authConfig)) {
+            $this->call('vendor:publish', [
+                '--provider' => 'Rapidez\Statamic\RapidezStatamicServiceProvider',
+                '--tag' => 'rapidez-user-model',
+            ]);
         }
 
         $migrationPath = database_path('migrations/0001_01_01_000000_create_users_table.php');

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -2,7 +2,11 @@
 
 namespace Rapidez\Statamic\Commands;
 
+use Exception;
+use Statamic\Support\Str;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 
 class InstallCommand extends Command
 {
@@ -12,20 +16,12 @@ class InstallCommand extends Command
 
     public function handle(): void
     {
-        $this->call('vendor:publish', [
-            '--tag' => 'runway-config',
-        ]);
+        $this->setupStatamic();
+        $this->setupUser();
+        $this->setupEloquentDriver();
 
-        $this->call('vendor:publish', [
-            '--provider' => 'Statamic\Eloquent\ServiceProvider',
-            '--tag' => 'statamic-eloquent-config',
-        ]);
-
-        $this->confirm('Did you set the table_prefix in config/statamic/eloquent-driver.php to "statamic_"?', 1);
-
-        $this->call('statamic:install:eloquent-driver');
-
-        $this->info('If you would like to store users in the database please make sure to follow this guide: https://statamic.dev/tips/storing-users-in-a-database#from-a-fresh-statamic-project');
+        $this->info('Running migrations...');
+        $this->call('migrate');
 
         if ($this->confirm('Would you like to configure a multisite? Note: Configuring a multisite requires a Statamic PRO license.')) {
             $this->call('statamic:multisite');
@@ -48,5 +44,143 @@ class InstallCommand extends Command
         }
 
         $this->info('Done 🚀');
+    }
+
+    protected function setupStatamic(): void
+    {
+        $this->info('Starting Statamic Setup...');
+        $this->call('statamic:install');
+        
+        $composerFile = base_path('composer.json');
+        
+        if (file_exists($composerFile)) {
+            $composerFileContents = File::get($composerFile);
+            $composer = json_decode($composerFileContents, true);
+
+            if (!isset($composer['scripts'])) {
+                $composer['scripts'] = [];
+            }
+
+            if (!isset($composer['scripts']['post-autoload-dump'])) {
+                $composer['scripts']['post-autoload-dump'] = [];
+            }
+
+            if (!in_array("@php artisan statamic:install --ansi", $composer['scripts']['post-autoload-dump'])) {
+                $composer['scripts']['post-autoload-dump'][] = "@php artisan statamic:install --ansi";
+            }
+
+            File::put($composerFile, json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+    }
+
+    protected function setupUser(): void
+    {
+        $this->info('Starting User Setup...');
+        $authConfig = config_path('auth.php');
+
+        if (!class_exists('\App\Models\User') && file_exists($authConfig)) {
+            $authFile = Str::of(File::get($authConfig));
+            $authFile = $authFile->replace(
+                'App\Models\User::class',
+                '\Rapidez\Statamic\Models\User::class'
+            );
+
+            File::put(
+                $authConfig,
+                $authFile->__toString()
+            );
+        }
+
+        $migrationPath = database_path('migrations/0001_01_01_000000_create_users_table.php');
+
+        if (!file_exists($migrationPath)) {
+            try {
+                $userTable = file_get_contents('https://raw.githubusercontent.com/laravel/laravel/refs/heads/11.x/database/migrations/0001_01_01_000000_create_users_table.php');
+
+                if (!$userTable) {
+                    throw new Exception('Failed to download the migration file.');
+                }
+
+                file_put_contents($migrationPath, $userTable);
+            } catch (Exception $e) {
+                Log::error('Error downloading migration file: ' . $e->getMessage());
+            }
+        }
+
+        if(!config('auth.passwords.activations') && file_exists($authConfig)) {
+            $authFile = Str::of(File::get($authConfig));
+            $authFile = $authFile->replace(
+                "'passwords' => [\n",
+                "'passwords' => [
+        'activations' => [
+            'provider' => 'users',
+            'table' => 'password_activation_tokens',
+            'expire' => 4320,
+            'throttle' => 60,
+        ],\n"
+            );
+
+            File::put(
+                $authConfig,
+                $authFile->__toString()
+            );
+        }
+
+        $usersConfig = config_path('statamic/users.php');
+
+        if ((config('statamic.users.passwords.resets') !== 'users' || config('statamic.users.passwords.activations') !== 'activations') && file_exists($usersConfig)) {
+            $usersFile = Str::of(File::get($usersConfig));
+            
+            if(config('statamic.users.passwords.resets') !== 'users') {
+                $usersFile = $usersFile->replace(
+                    "'resets' => config('auth.defaults.passwords'),",
+                    "'resets' => 'users',"
+                );
+            }
+
+            if(config('statamic.users.passwords.activations') !== 'activations') {
+                $usersFile = $usersFile->replace(
+                    "'activations' => config('auth.defaults.passwords'),",
+                    "'activations' => 'activations',"
+                );
+            }
+            
+            File::put(
+                $usersConfig,
+                $usersFile->__toString()
+            );
+        }
+
+        $this->call('statamic:auth:migration');
+    }
+
+    protected function setupEloquentDriver(): void
+    {
+        $this->info('Starting Eloquent Driver Setup...');
+
+        $this->call('vendor:publish', [
+            '--tag' => 'runway-config',
+        ]);
+
+        $this->call('vendor:publish', [
+            '--provider' => 'Statamic\Eloquent\ServiceProvider',
+            '--tag' => 'statamic-eloquent-config',
+        ]);
+
+        $eloquentConfig = config_path('statamic/eloquent-driver.php');
+
+        if (file_exists($eloquentConfig)) {
+            File::put(
+                $eloquentConfig,
+                Str::of(File::get($eloquentConfig))
+                    ->replace(
+                        "'table_prefix' => env('STATAMIC_ELOQUENT_PREFIX', ''),",
+                        "'table_prefix' => env('STATAMIC_ELOQUENT_PREFIX', 'statamic_'),"
+                    )
+                    ->__toString()
+            );
+        }
+
+        $this->call('statamic:install:eloquent-driver');
     }
 }

--- a/src/Models/BaseUser.php
+++ b/src/Models/BaseUser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rapidez\Statamic\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Statamic\Notifications\PasswordReset;
+
+class BaseUser extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+
+    public function sendPasswordResetNotification($token): void
+    {
+        $this->notify(new PasswordReset($token));
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,37 +1,10 @@
 <?php
 
-namespace Rapidez\Statamic\Models;
+namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Notifications\Notifiable;
-use Statamic\Notifications\PasswordReset;
+use Rapidez\Statamic\Models\BaseUser;
 
-class User extends Authenticatable
+class User extends BaseUser
 {
-    use HasFactory, Notifiable;
-
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-    ];
-
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
-
-    protected function casts(): array
-    {
-        return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-        ];
-    }
-
-    public function sendPasswordResetNotification($token): void
-    {
-        $this->notify(new PasswordReset($token));
-    }
+    
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace Rapidez\Statamic\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rapidez\Statamic\Models;
+
+// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Statamic\Notifications\PasswordReset;
+
+class User extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+
+    public function sendPasswordResetNotification($token): void
+    {
+        $this->notify(new PasswordReset($token));
+    }
+}

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -196,6 +196,10 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             __DIR__.'/../config/rapidez/statamic.php' => config_path('rapidez/statamic.php'),
         ], 'config');
 
+        $this->publishes([
+            __DIR__.'/../src/Models/User.php' => app_path('Models/User.php'),
+        ], 'rapidez-user-model');
+
         return $this;
     }
 


### PR DESCRIPTION
Changed the flow for the install command a bit, also added the configuration for the User model so we don't need https://github.com/rapidez/statamic/pull/90 anymore.

The flow of the install command now is as follows:

- We're starting with setting up Statamic by running the statamic:install command followed up by adding `@php artisan statamic:install --ansi` into the post-autoload-dump, as Statamic's install command doesn't do that.

Next we setup everything for the user by: 
- Setting the User model from the rapidez/statamic package in the auth config.
- Checking if the user migration exists, if not we get it from the Laravel repository.
- We change some config files and to comply with what's needed according to https://statamic.dev/tips/storing-users-in-a-database#in-an-existing-laravel-app
- We run the `statamic:auth:migration` command.

Now we setup everything for the Eloquent Driver by: 
- Publishing the config files and changing the default table_prefix
- Calling the `statamic:install:eloquent-driver` command to configure the Eloquent Driver

At last we ask the user to:
- Configure the multisite
- Publish the Collections, Blueprints, Fieldsets & Views from rapidez/statamic
- Make a Statamic user

Furthermore i changed the version of `rapidez/sitemap` to `^3.0` for it to work with Rapidez v3.
