### PR TITLE
[5.x] Use the retrieved event instead of having to overwrite getAttributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "rapidez/core": "^2.13|^3.0",
         "rapidez/sitemap": "^3.0",
         "spatie/once": "*",
-        "statamic-rad-pack/runway": "^7.6",
+        "statamic-rad-pack/runway": "^8.3",
         "statamic/cms": "^5.47",
         "statamic/eloquent-driver": "^4.9",
         "tdwesten/statamic-builder": "^1.0",

--- a/config/rapidez/statamic.php
+++ b/config/rapidez/statamic.php
@@ -49,19 +49,16 @@ return [
             \Rapidez\Statamic\Models\Product::class => [
                 'name' => 'Products',
                 'title_field' => 'name',
-                'cp_icon' => 'table',
             ],
 
             \Rapidez\Statamic\Models\Category::class => [
                 'name' => 'Categories',
                 'title_field' => 'name',
-                'cp_icon' => 'array',
             ],
 
             \Rapidez\Statamic\Models\Brand::class => [
                 'name' => 'Brands',
                 'title_field' => 'value_store',
-                'cp_icon' => 'tags',
                 'order_by' => 'sort_order',
             ],
 
@@ -69,7 +66,6 @@ return [
                 'name' => 'Product Attributes',
                 'read_only' => true,
                 'title_field' => 'frontend_label',
-                'cp_icon' => 'tags',
                 'listing' => [
                     'columns' => [
                         'attribute_code',
@@ -99,7 +95,6 @@ return [
                 'name' => 'Product Attribute Options',
                 'read_only' => true,
                 'title_field' => 'display_value',
-                'cp_icon' => 'list-bullets',
                 'listing' => [
                     'columns' => [
                         'option_id',

--- a/src/Models/Traits/HasContentEntry.php
+++ b/src/Models/Traits/HasContentEntry.php
@@ -2,30 +2,12 @@
 
 namespace Rapidez\Statamic\Models\Traits;
 
-use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Rapidez\Statamic\Observers\RunwayObserver;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 
 trait HasContentEntry
 {
-    public function getAttributes()
-    {
-        parent::getAttributes();
-
-        // Had some issues with non-existing models and attributes,
-        // this fixed that but not sure yet if this is the way.
-        if ($this->exists && $entry = ($this->entry ?? '')) {
-            $this->attributes = array_merge(
-                $entry->data()->toArray(),
-                $this->attributes
-            );
-        }
-
-        return $this->attributes;
-    }
-
     protected function entry(): Attribute
     {
         if (!app()->runningInConsole()) {

--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -12,7 +12,7 @@ class RunwayObserver
     public function updating(Model $model)
     {
         $entry = $model->entry;
-        
+
         if (!$entry) {
             $entry = Entry::make()
                 ->collection($model->collection)

--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -12,7 +12,7 @@ class RunwayObserver
     public function updating(Model $model)
     {
         $entry = $model->entry;
-    
+        
         if (!$entry) {
             $entry = Entry::make()
                 ->collection($model->collection)
@@ -41,13 +41,25 @@ class RunwayObserver
         return false;
     }
 
+    public function retrieved(Model $model)
+    {
+        $originalAttributes = $model->getAttributes();
+        
+        if ($model->exists && $modelEntry = ($model->entry ?? '')) {
+            $model->setRawAttributes(array_merge(
+                $modelEntry->data()->toArray(),
+                $originalAttributes
+            ));
+        }
+    }
+
     // Just to make sure you can't create or delete
-    public function creating(Model $product)
+    public function creating(Model $model)
     {
         return false;
     }
 
-    public function deleting(Model $product)
+    public function deleting(Model $model)
     {
         return false;
     }

--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -45,9 +45,9 @@ class RunwayObserver
     {
         $originalAttributes = $model->getAttributes();
         
-        if ($model->exists && $modelEntry = ($model->entry ?? '')) {
+        if ($model->exists && $model->entry) {
             $model->setRawAttributes(array_merge(
-                $modelEntry->data()->toArray(),
+                $model->entry->data()->toArray(),
                 $originalAttributes
             ));
         }


### PR DESCRIPTION
I've tested this with all the types (Brands, Categories and Products). This will add the right attributes to the model and render them in the entry in the backend of Statamic. This won't change anything for the frontend. It's still adding the content to the views as expected.

I also updated Runway. There's been some fixes for relation fields between Runway models. If you have a relations field on a Runway model called "products" it expected to have a "products" relation on the runway model. This is fixed now.

The upgrade guide show's no high impacting changes that applicable for us: https://runway.duncanmcclean.com/upgrade-guides/v7-to-v8 