### PR TITLE
[5.x] Added custom cache invalidator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "rapidez/sitemap": "^3.0",
         "spatie/once": "*",
         "statamic-rad-pack/runway": "^7.6",
-        "statamic/cms": "^5.29",
+        "statamic/cms": "^5.47",
         "statamic/eloquent-driver": "^4.9",
         "tdwesten/statamic-builder": "^1.0",
         "tormjens/eventy": "^0.8"

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -36,6 +36,7 @@ use Statamic\StaticCaching\Middleware\Cache as StaticCache;
 use TorMorten\Eventy\Facades\Eventy;
 use Statamic\Facades\Site as SiteFacade;
 use Statamic\View\Cascade as StatamicCascade;
+use Rapidez\Statamic\StaticCaching\CustomInvalidator;
 
 class RapidezStatamicServiceProvider extends ServiceProvider
 {
@@ -77,6 +78,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             ->bootUtilities()
             ->bootBuilder()
             ->bootSitemaps()
+            ->bootStaticCaching()
             ->bootStack();
 
         Vue::register();
@@ -252,6 +254,17 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         return $this;
     }
 
+    public function bootStaticCaching(): static
+    {
+        if (!config('statamic.static_caching.invalidation.class')) {
+            config()->set(
+                'statamic.static_caching.invalidation.class',
+                CustomInvalidator::class
+            );
+        }
+        
+        return $this;
+    }
 
     public function bootStack() : static
     {

--- a/src/StaticCaching/CustomInvalidator.php
+++ b/src/StaticCaching/CustomInvalidator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rapidez\Statamic\StaticCaching;
+
+use Statamic\Eloquent\Globals\GlobalSet;
+use Statamic\Eloquent\Structures\Nav;
+use Statamic\Entries\Entry;
+use Statamic\StaticCaching\DefaultInvalidator;
+use Statamic\Support\Str;
+
+class CustomInvalidator extends DefaultInvalidator
+{
+    public function invalidate($item)
+    {
+        if ($item instanceof GlobalSet || $item instanceof Nav || $this->rules === 'all') {
+            return $this->cacher->flush();
+        }
+
+        $urls = [];
+
+        if ($item instanceof Entry && $item->collectionHandle() === 'categories' && $item->linked_category) {
+            $urls[] = Str::ensureLeft($item->linked_category['url_path'], '/');
+        }
+
+        if (count($urls) >= 1) {
+            $this->cacher->invalidateUrls($urls);
+            return;
+        }
+
+        parent::invalidate($item);
+    }
+}


### PR DESCRIPTION
5.x version of https://github.com/rapidez/statamic/pull/122

---

Added a basic cache invalidator for emptying the caches when the relevant content has changed.
This new class can also be extended and used as a base in projects where more custom validation rules are required.