### PR TITLE
Compile assets from the install command

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -43,6 +43,9 @@ class InstallCommand extends Command
             $this->call('statamic:make:user');
         }
 
+        $this->info('Running `yarn run prod`...');
+        passthru('yarn run prod');
+
         $this->info('Done 🚀');
     }
 


### PR DESCRIPTION
As `yarn run prod` will fail when it's running from `php artisan rapidez:install` and selecting Magento with:

> [vite]: Rollup failed to resolve import "/public/vendor/statamic/frontend/js/helpers.js" from "/Users/roy/code/rapidez2/vendor/rapidez/statamic/resources/js/components/FormConditions.vue".

But after this command `php artisan rapidez-statamic:install` it's working so just build at the end.