### PR TITLE
Replace CSRF token in the Vue form

### DIFF
--- a/resources/js/components/FormConditions.vue
+++ b/resources/js/components/FormConditions.vue
@@ -12,5 +12,13 @@ export default {
     render() {
         return this.$scopedSlots.default({ formData: this.formData });
     },
+    mounted() {
+        let token = this.$root.csrfToken
+        let csrfField = this.$el.querySelector('input[value="STATAMIC_CSRF_TOKEN"]')
+
+        if (csrfField && token && token !== 'STATAMIC_CSRF_TOKEN') {
+            csrfField.value = token
+        }
+    }
 }
 </script>


### PR DESCRIPTION
Sometimes the token is already replaced by Statamic, when Vue loads slower the token resets back to `STATAMIC_CSRF_TOKEN`. With this we're replacing on form load.