### PR TITLE
[5.x] InvalidateCacheCommand multistore compatible

### DIFF
--- a/src/Commands/InvalidateCacheCommand.php
+++ b/src/Commands/InvalidateCacheCommand.php
@@ -42,7 +42,7 @@ class InvalidateCacheCommand extends Command
                 $this->info('Cleared all urls (as we do not have a latest check date yet)');
                 $cacher->flush();
                 $this->setLatestCheckDate($writer);
-                return;
+                continue;
             }
             $this->setLatestCheckDate($writer);
 

--- a/src/Commands/InvalidateCacheCommand.php
+++ b/src/Commands/InvalidateCacheCommand.php
@@ -20,22 +20,31 @@ class InvalidateCacheCommand extends Command
 
     public $latestCheck;
 
+    public $staticCachePath;
+
     public function handle(Cacher $cacher, Writer $writer): void
     {
-        $this->latestCheck = $this->getLatestCheckDate();
-
-        if (!$this->latestCheck) {
-            $this->info('Cleared all urls (as we do not have a latest check date yet)');
-            $cacher->flush();
-            $this->setLatestCheckDate($writer);
-            return;
-        }
-        $this->setLatestCheckDate($writer);
-
         $stores = Rapidez::getStores();
+        $staticCachePathConfig = 'statamic.static_caching.strategies.full.path';
 
         foreach ($stores as $store) {
             Rapidez::setStore($store);
+           
+            if (is_array(config('statamic.static_caching.strategies.full.path'))) {
+                $staticCachePathConfig = $staticCachePathConfig . '.' . $store['code'];
+            }
+
+            $this->staticCachePath = config($staticCachePathConfig);
+
+            $this->latestCheck = $this->getLatestCheckDate();
+
+            if (!$this->latestCheck) {
+                $this->info('Cleared all urls (as we do not have a latest check date yet)');
+                $cacher->flush();
+                $this->setLatestCheckDate($writer);
+                return;
+            }
+            $this->setLatestCheckDate($writer);
 
             $this->urls = collect();
 
@@ -142,7 +151,7 @@ class InvalidateCacheCommand extends Command
     protected function getLatestCheckDate()
     {
         try {
-            return File::get(config('statamic.static_caching.strategies.full.path') . '/.last-invalidation');
+            return File::get($this->staticCachePath . '/.last-invalidation');
         } catch (FileNotFoundException $e) {
             return null;
         }
@@ -151,7 +160,7 @@ class InvalidateCacheCommand extends Command
     protected function setLatestCheckDate(Writer $writer): void
     {
         $writer->write(
-            config('statamic.static_caching.strategies.full.path') . '/.last-invalidation',
+            $this->staticCachePath . '/.last-invalidation',
             // With this we're just making sure the comparison
             // is done within the same timezone in MySQL.
             DB::selectOne('SELECT NOW() AS `current_time`')->current_time
@@ -161,7 +170,7 @@ class InvalidateCacheCommand extends Command
     protected function getPreviousStock()
     {
         try {
-            return json_decode(File::get(config('statamic.static_caching.strategies.full.path') . '/.product-stocks'), true, 512, JSON_THROW_ON_ERROR);
+            return json_decode(File::get($this->staticCachePath . '/.product-stocks'), true, 512, JSON_THROW_ON_ERROR);
         } catch (FileNotFoundException|\JsonException $e) {
             return [];
         }
@@ -171,7 +180,7 @@ class InvalidateCacheCommand extends Command
     {
         $writer = app(Writer::class);
         $writer->write(
-            config('statamic.static_caching.strategies.full.path') . '/.product-stocks',
+            $this->staticCachePath . '/.product-stocks',
             json_encode($previousStock)
         );
     }


### PR DESCRIPTION
This PR adds store code to static cache path when we have multiple paths defined, even though there might only be one store, the developer still could've set these config values as an array.

Tested on 4.x and 5.x, with multistore and single store.

4.x: #134 