### PR TITLE
[4.x] InvalidateCacheCommand multistore compatible

### DIFF
--- a/src/Commands/InvalidateCacheCommand.php
+++ b/src/Commands/InvalidateCacheCommand.php
@@ -41,7 +41,7 @@ class InvalidateCacheCommand extends Command
                 $this->info('Cleared all urls (as we do not have a latest check date yet)');
                 $cacher->flush();
                 $this->setLatestCheckDate($writer);
-                return;
+                continue;
             }
             
             $this->setLatestCheckDate($writer);


### PR DESCRIPTION
This PR adds store code to static cache path when we have multiple paths defined, even though there might only be one store, the developer still could've set these config values as an array.

Tested on 4.x and 5.x, with multistore and single store.

5.x: #133 