### PR TITLE
Redirect absolute domains ending in . to regular domain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "rapidez/sitemap": "^3.0",
         "spatie/once": "*",
         "statamic-rad-pack/runway": "^8.3",
-        "statamic/cms": "^5.47",
+        "statamic/cms": "^5.55",
         "statamic/eloquent-driver": "^4.9",
         "tdwesten/statamic-builder": "^1.0",
         "tormjens/eventy": "^0.8"

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -16,12 +16,9 @@ use Rapidez\Statamic\Commands\InstallCommand;
 use Rapidez\Statamic\Commands\InvalidateCacheCommand;
 use Rapidez\Statamic\Extend\SitesLinkedToMagentoStores;
 use Rapidez\Statamic\Forms\JsDrivers\Vue;
-use Rapidez\Statamic\Http\Controllers\ImportsController;
 use Rapidez\Statamic\Http\ViewComposers\StatamicGlobalDataComposer;
 use Rapidez\Statamic\Listeners\ClearNavTreeCache;
 use Rapidez\Statamic\Listeners\SetCollectionsForNav;
-use Rapidez\Statamic\Models\ProductAttribute;
-use Rapidez\Statamic\Models\ProductAttributeOption;
 use Rapidez\Statamic\Tags\Alternates;
 use Statamic\Events\GlobalSetDeleted;
 use Statamic\Events\GlobalSetSaved;
@@ -33,6 +30,7 @@ use Statamic\Facades\Utility;
 use Statamic\Http\Controllers\FrontendController;
 use Statamic\Sites\Sites;
 use Statamic\StaticCaching\Middleware\Cache as StaticCache;
+use Statamic\Http\Middleware\RedirectAbsoluteDomains;
 use TorMorten\Eventy\Facades\Eventy;
 use Statamic\Facades\Site as SiteFacade;
 use Statamic\View\Cascade as StatamicCascade;
@@ -56,6 +54,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
         $this->app->booted(function () {
             $router = app(Router::class);
             $router->pushMiddlewareToGroup('web', StaticCache::class);
+            $router->pushMiddlewareToGroup('web', RedirectAbsoluteDomains::class);
         });
         $this->app->afterBootstrapping(BootProviders::class, function () {
             // Prevent infinite locks by removing the static cache from the statamic.web middleware.


### PR DESCRIPTION
See: https://github.com/statamic/cms/pull/11782

Domains ending in . is breaking for sites implementing static caching. This change will automatically redirect those domains to the version not ending in .

(also removed some imports that were unused)