### PR TITLE
Check if the store exist before we go on

### DIFF
--- a/src/Commands/InvalidateCacheCommand.php
+++ b/src/Commands/InvalidateCacheCommand.php
@@ -29,7 +29,7 @@ class InvalidateCacheCommand extends Command
         foreach ($stores as $store) {
             $staticCachePathConfig = 'statamic.static_caching.strategies.full.path';
             $disabled = config('rapidez.statamic.sites.' . $store['code'] . '.attributes.disabled');
-            if (!in_array($store['code'], array_keys(config('rapidez.statamic.sites'))) || $disabled === false) {
+            if (!$disabled) {
                 continue;
             }
             

--- a/src/Commands/InvalidateCacheCommand.php
+++ b/src/Commands/InvalidateCacheCommand.php
@@ -28,6 +28,11 @@ class InvalidateCacheCommand extends Command
 
         foreach ($stores as $store) {
             $staticCachePathConfig = 'statamic.static_caching.strategies.full.path';
+            $disabled = config('rapidez.statamic.sites.' . $store['code'] . '.attributes.disabled');
+            if (!in_array($store['code'], array_keys(config('rapidez.statamic.sites'))) || $disabled === false) {
+                continue;
+            }
+            
             Rapidez::setStore($store);
             
             if (is_array(config('statamic.static_caching.strategies.full.path'))) {


### PR DESCRIPTION
When there is a store in magento that is not in statamic, this will throw an error as there is no static cache path defined.