### PR TITLE
[5.x] Fix db query running on composer install

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -41,9 +41,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        if (! app()->runningInConsole()) {
-            $this->app->extend(Sites::class, fn () => new SitesLinkedToMagentoStores());
-        }
+        $this->app->extend(Sites::class, fn () => new SitesLinkedToMagentoStores());
 
         $this->app->singleton(RapidezStatamic::class);
 

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -41,7 +41,9 @@ class RapidezStatamicServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->extend(Sites::class, fn () => new SitesLinkedToMagentoStores());
+        if (! app()->runningInConsole()) {
+            $this->app->extend(Sites::class, fn () => new SitesLinkedToMagentoStores());
+        }
 
         $this->app->singleton(RapidezStatamic::class);
 


### PR DESCRIPTION
This caused pipelines that don't instantiate a database to fail because it tried to run a db query.