### PR TITLE
[5.x] Hack in namespace so statamic gets the correct blueprint

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -175,6 +175,11 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             )]);
         }
 
+        if (! Statamic::isCpRoute()) {
+            Blueprint::addNamespace('collections.products', resource_path('blueprints/vendor/runway'));
+            Blueprint::addNamespace('collections.categories', resource_path('blueprints/vendor/runway'));
+        }
+
         return $this;
     }
 
@@ -188,7 +193,6 @@ class RapidezStatamicServiceProvider extends ServiceProvider
                     ->where('linked_product', config('frontend.product.sku'))
                     ->first();
 
-                Blueprint::addNamespace('collections.products', resource_path('blueprints/vendor/runway'));
                 $view->with('content', optionalDeep($entry));
             });
         }
@@ -201,7 +205,6 @@ class RapidezStatamicServiceProvider extends ServiceProvider
                     ->where('linked_category', config('frontend.category.entity_id'))
                     ->first();
 
-                Blueprint::addNamespace('collections.categories', resource_path('blueprints/vendor/runway'));
                 $view->with('content', optionalDeep($entry));
             });
         }

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -36,6 +36,8 @@ use TorMorten\Eventy\Facades\Eventy;
 use Statamic\Facades\Site as SiteFacade;
 use Statamic\View\Cascade as StatamicCascade;
 use Rapidez\Statamic\StaticCaching\CustomInvalidator;
+use Statamic\Facades\Blueprint;
+use Statamic\Statamic;
 
 class RapidezStatamicServiceProvider extends ServiceProvider
 {

--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -188,6 +188,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
                     ->where('linked_product', config('frontend.product.sku'))
                     ->first();
 
+                Blueprint::addNamespace('collections.products', resource_path('blueprints/vendor/runway'));
                 $view->with('content', optionalDeep($entry));
             });
         }
@@ -200,6 +201,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
                     ->where('linked_category', config('frontend.category.entity_id'))
                     ->first();
 
+                Blueprint::addNamespace('collections.categories', resource_path('blueprints/vendor/runway'));
                 $view->with('content', optionalDeep($entry));
             });
         }


### PR DESCRIPTION
When getting the entry directly like here, Statamic doesn't find the right blueprint because it only looks in the `collections/[handle]` folder. This is hardcoded within Statamic so there's no easy way around that. This means that all category pages and product pages in the frontend (not the backend) currently break due to there being no blueprint attached to them, giving you raw data instead of augmented data.

However, we can trick statamic into looking elsewhere by setting a custom namespace like this. It's a pretty gross hack, I don't like it. But it's the only thing I found that works.

We have to make sure it doesn't run when in the backend because otherwise it will show the extra blueprints from these hacky namespaces.