### PR TITLE
[5.x] Add searchable model for Rapidez indexing

### DIFF
--- a/src/Models/BaseEntry.php
+++ b/src/Models/BaseEntry.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rapidez\Statamic\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Rapidez\Core\Models\Model;
+use Rapidez\Core\Models\Traits\Searchable;
+use Statamic\Eloquent\Entries\Entry;
+use Statamic\Facades\Site;
+use TorMorten\Eventy\Facades\Eventy;
+
+class BaseEntry extends Model
+{
+    use Searchable;
+
+    protected $table = 'statamic_entries';
+    protected static $collection = 'pages';
+
+    protected $casts = [
+        'data' => 'json',
+        'date' => 'date',
+    ];
+
+    protected static function booting()
+    {
+        static::addGlobalScope('collection', function (Builder $builder) {
+            $builder->where('collection', static::$collection);
+        });
+
+        static::addGlobalScope('onlyCurrentSite', function (Builder $builder) {
+            $site = Site::findByMageRunCode(config('rapidez.store_code'));
+            $builder->where('site', $site);
+        });
+    }
+
+    public static function getModelName(): string
+    {
+        return 'statamic.' . static::$collection;
+    }
+
+    public static function getIndexName(): string
+    {
+        return 'statamic.' . static::$collection;
+    }
+
+    /** @return array<mixed> */
+    public function toSearchableArray(): array
+    {
+        $entry = Entry::fromModel($this);
+
+        /** @var array<mixed> $data */
+        $data = Eventy::filter('index.' . static::getModelName() . '.data', $entry->toArray(), $entry);
+        return $data;
+    }
+}

--- a/src/Models/BaseEntry.php
+++ b/src/Models/BaseEntry.php
@@ -43,13 +43,10 @@ class BaseEntry extends Model
         return 'statamic.' . static::$collection;
     }
 
-    /** @return array<mixed> */
     public function toSearchableArray(): array
     {
         $entry = Entry::fromModel($this);
-
-        /** @var array<mixed> $data */
-        $data = Eventy::filter('index.' . static::getModelName() . '.data', $entry->toArray(), $entry);
-        return $data;
+        
+        return Eventy::filter('index.' . static::getModelName() . '.data', $entry->toArray(), $entry);
     }
 }


### PR DESCRIPTION
This adds a model that you can overwrite to get basic Statamic data into your Rapidez indexer. Example usage:

```php
<?php

namespace App\Models;

use Rapidez\Statamic\Models\BaseEntry;
use Statamic\Eloquent\Entries\Entry;
use TorMorten\Eventy\Facades\Eventy;

class Blog extends BaseEntry
{
    protected static $collection = 'blog';

    public function toSearchableArray(): array
    {
        $entry = Entry::fromModel($this);

        return Eventy::filter('index.' . static::getModelName() . '.data', [
            'title' => $entry->title,
            'url' => $entry->url,
            'image' => $entry->image ? $entry->image->url() : '',
            'slug' => $entry->slug,
            'date' => $entry->date,
            'categories' => $entry->blog_categories->map(fn ($category) => [
                'title' => $category->title,
                'slug' => $category->slug,
            ]),
            'content' => is_array($entry->content) ? json_encode($entry->content) : $entry->content,
        ], $entry);
    }
}
```

I considered adding some default functionality to the `toSearchableArray` data so that by default you don't index a ton of stuff, but I couldn't really think of anything that's useful and generic enough for that.