### PR TITLE
[6.x] Allow for arbitrary link keys instead of just the primary key

### DIFF
--- a/src/Models/Traits/HasContentEntry.php
+++ b/src/Models/Traits/HasContentEntry.php
@@ -15,7 +15,7 @@ trait HasContentEntry
                 get: fn() => Entry::query()
                     ->where('collection', $this->collection)
                     ->where('site', Site::selected()->handle())
-                    ->where($this->linkField, $this?->{$this->getKeyName()} ?? null)
+                    ->where($this->linkField, $this?->{$this->linkKey ?? $this->getKeyName()} ?? null)
                     ->first(),
             )->shouldCache();    
         }

--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -16,7 +16,7 @@ class RunwayObserver
             $entry = Entry::make()
                 ->collection($model->collection)
                 ->locale(Site::selected()->handle())
-                ->data([$model->linkField => $model->{$model->getKeyName()}]);
+                ->data([$model->linkField => $model->{$model->linkKey ?? $model->getKeyName()}]);
         }
         
         $attributes = $model->getDirty();


### PR DESCRIPTION
This is useful for when you don't want to change your primary key, which could have various reasons.