### PR TITLE
Merge conflicting fields correctly

### DIFF
--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -52,7 +52,7 @@ class RunwayObserver
             ->keys()
             ->toArray();
 
-        // Exclude the potentional duplicated keys
+        // Exclude the potential duplicated keys
         // Ignore the Magento values in that case
         $originalAttributes = Arr::except(
             $model->getAttributes(),

--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -42,7 +42,22 @@ class RunwayObserver
 
     public function retrieved(Model $model)
     {
-        $originalAttributes = $model->getAttributes();
+        $fieldsOnRunwayResource = $model
+            ->runwayResource()
+            ->blueprint()
+            ->fields()
+            ->all()
+            // Always keep these from Magento
+            ->except(['entity_id', 'name'])
+            ->keys()
+            ->toArray();
+
+        // Exclude the potentional duplicated keys
+        // Ignore the Magento values in that case
+        $originalAttributes = Arr::except(
+            $model->getAttributes(),
+            $fieldsOnRunwayResource
+        );
         
         if ($model->exists && $model->entry) {
             $model->setRawAttributes(array_merge(


### PR DESCRIPTION
When you create for example a `meta_title` and `meta_description` field in the Runway category blueprint it will conflict with the Magento values. Before this the Statamic value will be used but when you revisit the category you'll see the Magento value. We could just merge it differently but when you clear the value it should actually be empty instead of having the Magento value saved in Statamic. With this approach we remove potential duplicated/conflicting values.