### PR TITLE
[6.x] Improve filtering of attributes on retrieved models

### DIFF
--- a/src/Observers/RunwayObserver.php
+++ b/src/Observers/RunwayObserver.php
@@ -47,8 +47,8 @@ class RunwayObserver
             ->blueprint()
             ->fields()
             ->all()
-            // Always keep these from Magento
-            ->except(['entity_id', 'name'])
+            // Filter all read_only variables because they should always come from magento
+            ->filter(fn($option) => $option->visibility() !== 'read_only')
             ->keys()
             ->toArray();
 


### PR DESCRIPTION
The `entity_id` and `name` are correct for products (although missing SKU) and categories, but not for the brands. As we've already made all the relevant fields read_only in the blueprint, we can just listen to that instead.