### PR TITLE
[6.x] Use brand collection instead of Runway model

### DIFF
--- a/config/rapidez/statamic.php
+++ b/config/rapidez/statamic.php
@@ -63,6 +63,7 @@ return [
                 'name' => 'Brands',
                 'title_field' => 'value_store',
                 'order_by' => 'sort_order',
+                'hidden' => true,
             ],
 
             \Rapidez\Statamic\Models\ProductAttribute::class => [

--- a/resources/blueprints/collections/brands/brand.yaml
+++ b/resources/blueprints/collections/brands/brand.yaml
@@ -1,0 +1,44 @@
+tabs:
+  main:
+    display: Main
+    sections:
+      -
+        fields:
+          -
+            handle: title
+            field:
+              type: text
+              required: true
+              localizable: true
+      -
+        display: 'Content bovenkant'
+        fields:
+          -
+            import: page_builder
+      -
+        display: 'Content onderkant'
+        fields:
+          -
+            import: page_builder
+            prefix: bottom_
+  sidebar:
+    display: Sidebar
+    sections:
+      -
+        fields:
+          -
+            handle: slug
+            field:
+              type: slug
+              localizable: true
+              validate:
+                - 'max:200'
+                - 'new \Statamic\Rules\UniqueEntryValue({collection}, {id}, {site})'
+  meta:
+    display: Meta
+    sections:
+    -
+      fields:
+      -
+        import: meta_data
+title: Brand

--- a/resources/views/brands/show.blade.php
+++ b/resources/views/brands/show.blade.php
@@ -18,12 +18,10 @@
             <h1 class="font-bold text-3xl mb-5">{{ $title }}</h1>
         @endif
         @if ($content)
-            <div class="prose prose-green max-w-none">
-                @include('rapidez-statamic::page_builder.content', ['content' => $content])
-            </div>
+            @include('rapidez-statamic::page_builder', ['content' => $content])
         @endif
         <x-rapidez::listing filter-query-string="{{ $brandAttribute->code }}:{{ $title }}" />
 
-        @include('rapidez-statamic::page_builder')
+        @include('rapidez-statamic::page_builder', ['content' => $bottom_content])
     </div>
 @endsection

--- a/src/Collections/Brands.php
+++ b/src/Collections/Brands.php
@@ -31,9 +31,4 @@ class Brands extends Base
     {
         return 'rapidez-statamic::brands.show';
     }
-
-    public function visible(): bool
-    {
-        return false;
-    }
 }


### PR DESCRIPTION
Brands is the only model that allows for having custom (Statamic) routes, the problem lies with saving the slug when you are on the edit page of a model entry.

Since we added the collection blueprint on the model page in kind of a hacky way it cant build the slug field correctly when set, it always tries to base it of the title instead of getting the slug from the database.

To fix this we should try and stay closer to Statamic by moving the edit to the collection.
I've set the model to hidden, as we do need the model for the import.
Then i've set the collection back to visible, so its available through the menu.

Also changed the default fields to a page builder top and bottom, as we do this manually in each project now anyways.
I will make a PR for 7.x later.