### PR TITLE
Added Support for OptionalDeep in determineEntryUrl

### DIFF
--- a/src/RapidezStatamic.php
+++ b/src/RapidezStatamic.php
@@ -3,6 +3,7 @@
 namespace Rapidez\Statamic;
 
 use Illuminate\Support\Facades\Cache;
+use Rapidez\BladeDirectives\OptionalDeep;
 use Statamic\Statamic;
 use Statamic\Eloquent\Entries\Entry;
 use Rapidez\Core\Facades\Rapidez;

--- a/src/RapidezStatamic.php
+++ b/src/RapidezStatamic.php
@@ -64,9 +64,13 @@ class RapidezStatamic
         return $tree;
     }
 
-    public function determineEntryUrl(Entry|Page|string $entry, string $nav = 'global-link'): string
+    public function determineEntryUrl(Entry|Page|string|OptionalDeep $entry, string $nav = 'global-link'): string
     {
         $cacheKey = $nav . '-' . config('rapidez.store');
+
+        if ($entry instanceof OptionalDeep) {
+            $entry = $entry->get();
+        }
 
         if (is_string($entry)) {
             return $entry;


### PR DESCRIPTION
ref: AN-409

When using data from a global, or from a product, we wrap it in an optionalDeep. However, this function does not support that and will subsequently throw an error.