### PR TITLE
[8.x] Fix url from entries in rapidez 5.x

### DIFF
--- a/src/RapidezStatamic.php
+++ b/src/RapidezStatamic.php
@@ -97,7 +97,7 @@ class RapidezStatamic
             }
 
             $siteUrl = Str::finish(Site::current()->absoluteUrl(), '/');
-            $urlPath = ltrim($entry->{$linkedRunwayResourceKey}['url'], ',');
+            $urlPath = ltrim($entry->{$linkedRunwayResourceKey}['url'], '/');
 
             $this->navCache[$nav][$entry->id()] = $siteUrl . $urlPath;
 

--- a/src/RapidezStatamic.php
+++ b/src/RapidezStatamic.php
@@ -90,20 +90,14 @@ class RapidezStatamic
                 return $entry->url() ?? '';
             }
 
-            $suffix = match (true) {
-                str($linkedRunwayResourceKey)->contains('category') => Rapidez::config('catalog/seo/category_url_suffix', ''),
-                str($linkedRunwayResourceKey)->contains('product') => Rapidez::config('catalog/seo/product_url_suffix', ''),
-                default => '',
-            };
-
-            if (!isset($entry->{$linkedRunwayResourceKey}['url_path'])) {
+            if (!isset($entry->{$linkedRunwayResourceKey}['url'])) {
                 $this->navCache[$nav][$entry->id()] = '';
 
                 return '';
             }
 
             $siteUrl = Str::finish(Site::current()->absoluteUrl(), '/');
-            $urlPath = $entry->{$linkedRunwayResourceKey}['url_path'] . $suffix;
+            $urlPath = ltrim($entry->{$linkedRunwayResourceKey}['url'], ',');
 
             $this->navCache[$nav][$entry->id()] = $siteUrl . $urlPath;
 


### PR DESCRIPTION
Since 5.x we want to use `url` instead. This also includes the suffix automatically, so we don't have to manually add it.