### PR TITLE
[8.x] Also flush application cache on global flush

### DIFF
--- a/src/StaticCaching/CustomInvalidator.php
+++ b/src/StaticCaching/CustomInvalidator.php
@@ -2,6 +2,7 @@
 
 namespace Rapidez\Statamic\StaticCaching;
 
+use Illuminate\Support\Facades\Cache;
 use Statamic\Eloquent\Globals\GlobalSet;
 use Statamic\Eloquent\Structures\Nav;
 use Statamic\Eloquent\Structures\NavTree;
@@ -19,6 +20,7 @@ class CustomInvalidator extends DefaultInvalidator
             || $item instanceof NavTree
             || $this->rules === 'all'
         ) {
+            Cache::flush();
             return $this->cacher->flush();
         }
 


### PR DESCRIPTION
Without this, things like the navigation menu will not get invalidated properly. As we can't perfectly predict which caches are necessary to clear (including, but not limited to, use of `@includeCached`), the only good solution is to flush the entire cache.