### PR TITLE
[6.x] Open details accordions when there are errors

### DIFF
--- a/resources/js/components/FormSubmission.vue
+++ b/resources/js/components/FormSubmission.vue
@@ -1,4 +1,5 @@
 <script>
+import { useEventListener } from '@vueuse/core'
 import '/public/vendor/statamic/frontend/js/helpers.js'
 Vue.prototype.Statamic = window.Statamic
 
@@ -28,6 +29,14 @@ export default {
         if (csrfField && token && token !== 'STATAMIC_CSRF_TOKEN') {
             csrfField.value = token
         }
+
+        // Recursively open up any `details` accordions that have errors in them
+        useEventListener(this.$el, 'invalid', (event) => {
+            let current = event.target
+            while(current = current.parentElement.closest('details')) {
+                current.open = true
+            }
+        }, true)
     },
 
     methods: {


### PR DESCRIPTION
ref: BORDEX-1410

This issue arose in a certain project because there were accordions inside of the form, but they couldn't be focused or shown to have an error because they were hidden in a closed accordion. This event listener opens these accordions (recursively, in case there are multiple parent accordions) so that the field is shown.