### PR TITLE
Also flush cache on form change

### DIFF
--- a/src/StaticCaching/CustomInvalidator.php
+++ b/src/StaticCaching/CustomInvalidator.php
@@ -7,6 +7,7 @@ use Statamic\Eloquent\Globals\GlobalSet;
 use Statamic\Eloquent\Structures\Nav;
 use Statamic\Eloquent\Structures\NavTree;
 use Statamic\Entries\Entry;
+use Statamic\Forms\Form;
 use Statamic\StaticCaching\DefaultInvalidator;
 use Statamic\Support\Str;
 
@@ -18,6 +19,7 @@ class CustomInvalidator extends DefaultInvalidator
             $item instanceof GlobalSet
             || $item instanceof Nav
             || $item instanceof NavTree
+            || $item instanceof Form
             || $this->rules === 'all'
         ) {
             Cache::flush();


### PR DESCRIPTION
ref: VGB-1045

When a form gets changed, this could require a cache clear on multiple pages where this form gets imported.

I'm not sure if we should consider looking into a way to find exactly which urls need to be invalidated for all of these full flush types. It's probably not worthwhile?