### PR TITLE
Fix replicators not working from Runway resource blueprints

### DIFF
--- a/src/RapidezStatamicServiceProvider.php
+++ b/src/RapidezStatamicServiceProvider.php
@@ -189,6 +189,7 @@ class RapidezStatamicServiceProvider extends ServiceProvider
             Blueprint::addNamespace('collections.products', resource_path('blueprints/vendor/runway'));
             Blueprint::addNamespace('collections.categories', resource_path('blueprints/vendor/runway'));
         }
+        Blueprint::addNamespace('vendor.runway', resource_path('blueprints/vendor/runway'));
 
         return $this;
     }


### PR DESCRIPTION
ref: AN-432

Since what I assume would be the Statamic 6 upgrade, the `vendor.runway` hint path is used for the blueprint token in Replicators and Bards. This path does not get recognized because of the way we have set up our Runway integration.

This means that instead of using the correct path `runway::category` using the runway namespace, it will spit out the raw `vendor.runway.category` and look for a blueprint with that exact name.

This line gives Statamic enough information to not do this, and look for the blueprint in the proper location.