### PR TITLE
Support non-integer key types

### DIFF
--- a/src/Models/BaseEntry.php
+++ b/src/Models/BaseEntry.php
@@ -14,6 +14,7 @@ class BaseEntry extends Model
     use Searchable;
 
     protected $table = 'statamic_entries';
+    protected $keyType = 'string';
     protected static $collection;
 
     protected $casts = [


### PR DESCRIPTION
ref: AN-432

We ran into an issue where Runway entries using UUIDs didn't get saved properly. Turns out it was trying to cast the UUID into an integer while saving because it's the primary key, because Laravel automatically casts primary keys to whatever the defined `keyType` is.

By adding `string` as the `keyType` here we allow any type of key to be used.