### PR TITLE
Update formfields added extra checks for possible empty display fields

### DIFF
--- a/resources/views/form_fields/checkboxes.blade.php
+++ b/resources/views/form_fields/checkboxes.blade.php
@@ -1,11 +1,15 @@
+@if ($field['display'] ?? false)
+    <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+@endif
 @foreach($field['options'] as $key => $label)
     <x-rapidez::input.checkbox
         :name="$field['handle']"
+        :id="$key"
         :value="$key"
         :type="$field['type']"
         :class="$field['error'] ? 'border-red-500' : ''"
         :required="in_array('required', $field['validate'] ?? [])"
-        v-model="formData.{{ $field['handle'] }}"
+        v-model="formData.{{ $key }}"
     >
         {{ $label }}
     </x-rapidez::input.checkbox>

--- a/resources/views/form_fields/radio.blade.php
+++ b/resources/views/form_fields/radio.blade.php
@@ -1,3 +1,6 @@
+@if ($field['display'] ?? false)
+    <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+@endif
 @foreach($field['options'] as $key => $label)
     <x-rapidez::input.radio
         :name="$field['handle']"

--- a/resources/views/form_fields/select.blade.php
+++ b/resources/views/form_fields/select.blade.php
@@ -1,5 +1,7 @@
 <label>
-    <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+    @if ($field['display'] ?? false)
+        <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+    @endif
     <x-rapidez::input.select
         :name="$field['handle']"
         :value="$field['old'] ?: $field['default'] ?? ''"

--- a/resources/views/form_fields/text.blade.php
+++ b/resources/views/form_fields/text.blade.php
@@ -1,5 +1,7 @@
 <label>
-    <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+    @if ($field['display'] ?? false)
+        <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+    @endif
     <x-rapidez::input
         :name="$field['handle']"
         :type="$field['input_type']"

--- a/resources/views/form_fields/textarea.blade.php
+++ b/resources/views/form_fields/textarea.blade.php
@@ -1,5 +1,7 @@
 <label>
-    <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+    @if ($field['display'] ?? false)
+        <x-rapidez::label>@lang($field['display'])</x-rapidez::label>
+    @endif
     <x-rapidez::input.textarea
         :name="$field['handle']"
         :value="$field['value']"


### PR DESCRIPTION
- Added labels above radio's and checkboxes. 
- Added checks for `$field['display']` this could be left empty in Statamic because it is not a required field. 

_Maybe nice to have but we could discuss this later option to show instructions field on the frontend below or above the field_
